### PR TITLE
Fix: Trello Attachment URL Detection

### DIFF
--- a/frontend/services/trello-funcs.ts
+++ b/frontend/services/trello-funcs.ts
@@ -312,9 +312,19 @@ export class TrelloClient {
     private static extractCardIDFromAttachment(
         attachment: TrelloAttachment,
     ): string | null {
-        const regex = /https:\/\/trello\.com\/c\/(.+?)\//;
-        const match = regex.exec(attachment.url);
-        return match ? match[1] : null;
+        try {
+            const url = new URL(attachment.url);
+            if (url.hostname !== "trello.com") {
+                return null;
+            }
+            // check for /c/{cardID} pattern and extract id if it exists
+            const regex = /^\/c\/([a-zA-Z0-9]+)/;
+            const match = regex.exec(url.pathname);
+            return match ? match[1] : null;
+        } catch {
+            // invalid url
+            return null;
+        }
     }
 
     // gets (issue) card IDs that are attachments to an event card


### PR DESCRIPTION
## code changes
- use URL constructor to more robustly detect Trello domain
- capture cardID using more robust regex  
## issues closed
- Closes #44
## test plan
- android simulator
- [jsfiddle](https://jsfiddle.net/Lehdtwg4/) for detection logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Trello card link validation for improved security and reliability. The system now performs stricter validation checks to ensure that only valid Trello card links are successfully processed. Invalid, malformed, or non-Trello links that don't conform to the expected URL format are now properly detected and rejected, enhancing overall system robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->