### PR TITLE
Move issues to completed on event publish

### DIFF
--- a/frontend/app/edit-draft.tsx
+++ b/frontend/app/edit-draft.tsx
@@ -10,7 +10,8 @@ import { getEventById, publishEvent, saveDraft } from "@/services/event-service"
 import { TrelloClient } from "@/services/trello-funcs";
 import {
     fetchDocumentTrailIssues,
-    moveCardToCompleted,
+    moveCardAttachmentsToCompleted,
+    moveCardToCompleted
 } from "@/services/trello-service";
 import { TrailDocumentIssueItem } from "@/types/trail-types";
 import { Ionicons } from "@expo/vector-icons";
@@ -119,6 +120,7 @@ export default function EditDraftScreen() {
         try {
             await publishEvent(event.eventId);
             await moveCardToCompleted(event.trelloCardId, API_KEY);
+            await moveCardAttachmentsToCompleted(event.trelloCardId, API_KEY);
             setPublishModalVisible(false);
             router.replace("/home-screen");
         } catch (e) {

--- a/frontend/services/trello-service.ts
+++ b/frontend/services/trello-service.ts
@@ -214,8 +214,20 @@ export async function moveCardAttachmentsToCompleted(
     const attachments = await trello.getEventCardAttachmentIDs(eventCard);
 
     // move each attachment (issue card) to completed issues list
-    for (const attachmentId of attachments) {
-        await trello.moveCardToList(attachmentId, list.id);
+    const results = await Promise.allSettled(
+        attachments.map((attachmentId) =>
+            trello.moveCardToList(attachmentId, list.id),
+        ),
+    );
+    const failedAttachments = results
+        .map((result, index) =>
+            result.status === "rejected" ? attachments[index] : null,
+        )
+        .filter((id) => id !== null);
+    if (failedAttachments.length > 0) {
+        throw new Error(
+            `Failed to move ${failedAttachments.length} attachment${failedAttachments.length === 1 ? "" : "s"}: ${failedAttachments.join(", ")}`,
+        );
     }
 }
 

--- a/frontend/services/trello-service.ts
+++ b/frontend/services/trello-service.ts
@@ -9,6 +9,7 @@ const BOARD_NAME = "MVT Mock Board";
 const TRAIL_ISSUES_LIST = "Trail Issues and Problems - Intake";
 const UPCOMING_EVENTS_LIST = "Scheduled Events";
 const COMPLETED_EVENTS_LIST = "Completed Events (From App)";
+const COMPLETED_ISSUES_LIST = "Completed Issues";
 
 // parses trello description into structured fields
 function parseEventDescription(desc: string) {
@@ -112,7 +113,9 @@ export async function fetchUpcomingEvents(
     return Promise.all(
         cards.map(async (card) => {
             const imgAttachmentUrl = getFirstImageAttachment(card.attachments);
-			const imageUrl = imgAttachmentUrl ? await trello.loadTrelloImage(imgAttachmentUrl) : null;
+            const imageUrl = imgAttachmentUrl
+                ? await trello.loadTrelloImage(imgAttachmentUrl)
+                : null;
             const parsed = parseEventDescription(card.desc ?? "");
             return {
                 id: card.id,
@@ -120,19 +123,23 @@ export async function fetchUpcomingEvents(
                 description: card.desc ?? "",
                 date: card.eventDate,
                 imageUrl,
-                ...parsed
+                ...parsed,
             };
         }),
     );
 }
 
 // finds the first image (not trello card or other) attached to a card to display with it
-function getFirstImageAttachment(attachments: TrelloAttachment[] | undefined): string | null {
-	if (!attachments || attachments.length === 0) return null;
+function getFirstImageAttachment(
+    attachments: TrelloAttachment[] | undefined,
+): string | null {
+    if (!attachments || attachments.length === 0) return null;
 
-	const pattern = /image/;
-	const img = attachments.find((attachment) => pattern.exec(attachment.mimeType));
-	return img?.url ?? null;
+    const pattern = /image/;
+    const img = attachments.find((attachment) =>
+        pattern.exec(attachment.mimeType),
+    );
+    return img?.url ?? null;
 }
 
 // creates a new event card in the Scheduled Events list with the card name prefixed with date
@@ -186,6 +193,30 @@ export async function moveCardToCompleted(
     if (!list) throw new Error(`List "${COMPLETED_EVENTS_LIST}" not found`);
 
     await trello.moveCardToList(cardId, list.id);
+}
+
+// moves all attachments from a card to completed issues list
+export async function moveCardAttachmentsToCompleted(
+    cardId: string,
+    key: string,
+): Promise<void> {
+    const trello = new TrelloClient(key);
+    const boards = await trello.getBoards();
+    const board = boards.find((b) => b.name === BOARD_NAME);
+    if (!board) throw new Error(`Board "${BOARD_NAME}" not found`);
+
+    const lists = await trello.getLists(board.id);
+    const list = lists.find((l) => l.name === COMPLETED_ISSUES_LIST);
+    if (!list) throw new Error(`List "${COMPLETED_ISSUES_LIST}" not found`);
+
+    // get all attachments on the card
+    const eventCard = await trello.getEventCardByID(cardId, true);
+    const attachments = await trello.getEventCardAttachmentIDs(eventCard);
+
+    // move each attachment (issue card) to completed issues list
+    for (const attachmentId of attachments) {
+        await trello.moveCardToList(attachmentId, list.id);
+    }
 }
 
 // adds album link to a trello event card description


### PR DESCRIPTION
## task assigned
- make the column for completed issues
- move issue cards attached to an event card into the completed column when the event is published
## code changes
- move attachments after event card is moved in `handleConfirmPublish` in `edit_draft.tsx`
- created helper function in `trello-service.ts` to move all cards attached to the event card to the completed issues column in Trello
## issues closed
- addresses #46 
## test plan
- created a new event and attached issues to the event card manually in Trello
- started the event then stopped it and published to Trello
- issue cards moved to the newly created column

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When publishing a draft, Trello card attachments are now automatically moved to the Completed Issues state along with the card itself.

* **Chores**
  * Improved Trello service implementation and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->