### PR TITLE
Update save notepad info logic

### DIFF
--- a/frontend/app/active-event.tsx
+++ b/frontend/app/active-event.tsx
@@ -38,9 +38,7 @@ export default function ActiveEventScreen() {
         if (!event) return;
         setEnding(true);
         try {
-            if (notes && notes.trim() !== "") {
-                await updateEventNotes(event.eventId, notes.trim());
-            }
+            await updateEventNotes(event.eventId, notes?.trim() ?? "");
             await setEventInactive(event.eventId);
             setModalVisible(false);
             router.replace({

--- a/frontend/app/active-event.tsx
+++ b/frontend/app/active-event.tsx
@@ -1,6 +1,10 @@
 import EndEventModal from "@/components/ui/end-event-modal";
 import type { Event } from "@/services/event-service";
-import { getActiveEvent, saveDraft, setEventInactive } from "@/services/event-service";
+import {
+    getActiveEvent,
+    setEventInactive,
+    updateEventNotes
+} from "@/services/event-service";
 import { useNavigation } from "@react-navigation/native";
 import { useRouter } from "expo-router";
 import React, { useEffect, useState } from "react";
@@ -35,7 +39,7 @@ export default function ActiveEventScreen() {
         setEnding(true);
         try {
             if (notes && notes.trim() !== "") {
-                await saveDraft(event.eventId, notes);
+                await updateEventNotes(event.eventId, notes.trim());
             }
             await setEventInactive(event.eventId);
             setModalVisible(false);

--- a/frontend/app/active-event.tsx
+++ b/frontend/app/active-event.tsx
@@ -1,6 +1,6 @@
 import EndEventModal from "@/components/ui/end-event-modal";
 import type { Event } from "@/services/event-service";
-import { getActiveEvent, setEventInactive } from "@/services/event-service";
+import { getActiveEvent, saveDraft, setEventInactive } from "@/services/event-service";
 import { useNavigation } from "@react-navigation/native";
 import { useRouter } from "expo-router";
 import React, { useEffect, useState } from "react";
@@ -30,10 +30,13 @@ export default function ActiveEventScreen() {
             .finally(() => setLoading(false));
     }, []);
 
-    const handleConfirmEnd = async () => {
+    const handleConfirmEnd = async (notes?: string) => {
         if (!event) return;
         setEnding(true);
         try {
+            if (notes && notes.trim() !== "") {
+                await saveDraft(event.eventId, notes);
+            }
             await setEventInactive(event.eventId);
             setModalVisible(false);
             router.replace({

--- a/frontend/app/drafts.tsx
+++ b/frontend/app/drafts.tsx
@@ -82,7 +82,7 @@ export default function DraftsScreen() {
                         onPress={() =>
                             router.push({
                                 pathname: "/edit-draft",
-                                params: { eventId: draft.eventId },
+                                params: { eventId: draft.eventId, notes: draft.notes ?? "" },
                             })
                         }>
                         <View style={styles.rowIcon}>

--- a/frontend/app/edit-draft.tsx
+++ b/frontend/app/edit-draft.tsx
@@ -118,9 +118,9 @@ export default function EditDraftScreen() {
         }
         setPublishing(true);
         try {
-            await publishEvent(event.eventId);
             await addNotesToCard(event.trelloCardId, notes, API_KEY);
             await moveCardToCompleted(event.trelloCardId, API_KEY);
+            await publishEvent(event.eventId);
             setPublishModalVisible(false);
             router.replace("/home-screen");
         } catch (e) {

--- a/frontend/app/edit-draft.tsx
+++ b/frontend/app/edit-draft.tsx
@@ -9,6 +9,7 @@ import type { Event } from "@/services/event-service";
 import { getEventById, publishEvent, saveDraft } from "@/services/event-service";
 import { TrelloClient } from "@/services/trello-funcs";
 import {
+    addNotesToCard,
     fetchDocumentTrailIssues,
     moveCardToCompleted,
 } from "@/services/trello-service";
@@ -38,7 +39,7 @@ export default function EditDraftScreen() {
     const [error, setError] = useState<string>();
     const [issues, setIssues] = useState<TrailDocumentIssueItem[]>([]);
     const [issuesError, setIssuesError] = useState<string | null>(null);
-    const [notepad, setNotepad] = useState("");
+    const [notes, setNotes] = useState("");
     const [savingDraft, setSavingDraft] = useState(false);
     const [publishing, setPublishing] = useState(false);
     const [publishModalVisible, setPublishModalVisible] = useState(false);
@@ -56,7 +57,7 @@ export default function EditDraftScreen() {
                     return;
                 }
                 setEvent(e);
-                setNotepad(e.notepad ?? "");
+                setNotes(e.notes ?? "");
             })
             .catch((e) => setError((e as Error).message))
             .finally(() => setLoading(false));
@@ -101,7 +102,7 @@ export default function EditDraftScreen() {
         if (!event || savingDraft || publishing) return;
         setSavingDraft(true);
         try {
-            await saveDraft(event.eventId, notepad);
+            await saveDraft(event.eventId, notes);
             router.replace("/drafts");
         } catch (e) {
             Alert.alert("Save failed", (e as Error).message);
@@ -118,6 +119,7 @@ export default function EditDraftScreen() {
         setPublishing(true);
         try {
             await publishEvent(event.eventId);
+            await addNotesToCard(event.trelloCardId, notes, API_KEY);
             await moveCardToCompleted(event.trelloCardId, API_KEY);
             setPublishModalVisible(false);
             router.replace("/home-screen");
@@ -172,8 +174,8 @@ export default function EditDraftScreen() {
                     <Text style={styles.sectionTitle}>Notepad</Text>
                     <TextInput
                         style={styles.notepad}
-                        value={notepad}
-                        onChangeText={setNotepad}
+                        value={notes}
+                        onChangeText={setNotes}
                         multiline
                         placeholder="Add notes about this event"
                         placeholderTextColor="#bbb"

--- a/frontend/app/event-summary.tsx
+++ b/frontend/app/event-summary.tsx
@@ -3,7 +3,7 @@ import HomeHeader from "@/components/ui/header";
 import TrailEventHeader from "@/components/ui/trail-event-header";
 import type { Event, EventMetricsWithHours } from "@/services/event-service";
 import {
-	extractMetricsWithHours,
+    extractMetricsWithHours,
     getEventById,
     saveDraft,
 } from "@/services/event-service";
@@ -220,9 +220,9 @@ function MetricGridCard({ def, value, delay }: MetricGridCardProps) {
 
 export default function EventSummaryScreen() {
     const router = useRouter();
-    const { eventId, notepad } = useLocalSearchParams<{
+    const { eventId, notes } = useLocalSearchParams<{
         eventId: string;
-        notepad: string;
+        notes?: string;
     }>();
 
     const [saving, setSaving] = useState(false);
@@ -267,7 +267,7 @@ export default function EventSummaryScreen() {
         if (saving || savedDraft || savedTrello) return;
         setSaving(true);
         try {
-            await saveDraft(eventId, notepad);
+            await saveDraft(eventId, notes ?? event.notes ?? "");
             setSavedDraft(true);
         } catch {
             Alert.alert("Error", "Could not save event to drafts.");
@@ -376,7 +376,8 @@ export default function EventSummaryScreen() {
                     onPress={() => router.replace({
 						pathname: "/edit-draft",
 						params: {
-							eventId
+							eventId,
+                            notes: notes ?? event.notes ?? "",
 						}
 					})}
                     disabled={saving || savedDraft || savedTrello}>

--- a/frontend/app/setup-event.tsx
+++ b/frontend/app/setup-event.tsx
@@ -3,7 +3,7 @@ import Header from "@/components/ui/header";
 import { Palette } from "@/constants/theme";
 import { createEvent } from "@/services/event-service";
 import { createGoogleAlbum } from "@/services/googlePhotosAlbumsService";
-import { addAlbumLinkToCard, createEventCard } from "@/services/trello-service";
+import { addAlbumLinkToCard, addNotesToCard, createEventCard } from "@/services/trello-service";
 import { getDateString, parseAndValidateDate } from "@/utils/date";
 import { Feather } from "@expo/vector-icons";
 import RNDateTimePicker, { DateTimePickerEvent } from "@react-native-community/datetimepicker";
@@ -101,13 +101,29 @@ export default function SetupEventScreen() {
             const album = await createGoogleAlbum(title.trim());
             const albumUrl = album.productUrl ?? "";
 
+            const roles = ["Event Leader", "Zone Leaders", "Tool Haulers", "Glover Lover"];
+            const rolesDescription = [
+                eventLeader.trim(),
+                zoneLeaders.trim(),
+                toolHaulers.trim(),
+                gloverLover.trim()
+            ].map((role, idx) => role && `${roles[idx]}: ${role}`).join('\n').trim();
+            const modifiedDescription = `${rolesDescription}\n\n${description.trim() ? `Work Scope:\n${description.trim()}` : ""}`.trim();
+
             // creates a trello card and adds it to the Scheduled Events list
             const { cardId, cardUrl } = await createEventCard(
                 title.trim(),
                 getDateString(eventDate),
-                description.trim(),
+                modifiedDescription,
                 TRELLO_KEY,
             );
+
+            // add notes to the trello card
+            await addNotesToCard(
+                cardId,
+                notes.trim(),
+                TRELLO_KEY,
+            )
 
             // adds the album link to the trello card
             await addAlbumLinkToCard(

--- a/frontend/app/trail-document-screen.tsx
+++ b/frontend/app/trail-document-screen.tsx
@@ -2,6 +2,7 @@ import BottomNav from "@/components/ui/bottom-nav";
 import HomeHeader from "@/components/ui/header";
 import { TrailDocIssuesCard } from "@/components/ui/trail-doc-issues-card";
 import TrailEventHeader from "@/components/ui/trail-event-header";
+import TrailMetricsSection from "@/components/ui/trail-metrics-section";
 import type { Event } from "@/services/event-service";
 import { getActiveEvent, getEventById } from "@/services/event-service";
 import { TrelloClient } from "@/services/trello-funcs";
@@ -19,7 +20,6 @@ import {
     TouchableOpacity,
     View,
 } from "react-native";
-import TrailMetricsSection from "@/components/ui/trail-metrics-section";
 
 const API_KEY = process.env.EXPO_PUBLIC_TRELLO_API_KEY;
 
@@ -45,7 +45,7 @@ export default function TrailDocumentScreen() {
         Record<string, { before?: string; after?: string }>
     >({});
     const [loadError, setLoadError] = useState<string | null>(null);
-    const [notepad, setNotepad] = useState("");
+    const [notes, setNotes] = useState("");
     const [activeEventId, setActiveEventId] = useState<string | null>(null);
     const [issuesError, setIssuesError] = useState<string | null>(null);
 
@@ -74,8 +74,13 @@ export default function TrailDocumentScreen() {
         }
         getEventById(eventId)
             .then((e) => {
-                if (e) setEvent(e);
-                else setError("Event not found.");
+                if (e) {
+                    setEvent(e);
+                    // load existing notes from event creation
+                    setNotes(e.notes || "");
+                } else {
+                    setError("Event not found.");
+                }
             })
             .catch((e) => setError((e as Error).message))
             .finally(() => setLoading(false));
@@ -166,12 +171,13 @@ export default function TrailDocumentScreen() {
                     <TrailEventHeader
                         event={event}
                         variant="document"
+                        notes={notes}
                         onStop={() =>
                             router.replace({
                                 pathname: "/event-summary",
                                 params: {
                                     eventId: event.eventId,
-                                    notepad: notepad,
+                                    notes: notes,
                                 },
                             })
                         }
@@ -271,8 +277,8 @@ export default function TrailDocumentScreen() {
                                 marginBottom: 24,
                                 backgroundColor: "#FAFAFA",
                             }}
-                            value={notepad}
-                            onChangeText={setNotepad}
+                            value={notes}
+                            onChangeText={setNotes}
                             multiline
                             placeholder="Start documenting the event"
                             placeholderTextColor="#bbb"

--- a/frontend/components/ui/end-event-modal.tsx
+++ b/frontend/components/ui/end-event-modal.tsx
@@ -1,6 +1,6 @@
 import { Palette } from "@/constants/theme";
 import { Feather } from "@expo/vector-icons";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import {
     ActivityIndicator,
     Modal,
@@ -14,7 +14,8 @@ type Props = {
     visible: boolean;
     eventTitle: string;
     onCancel: () => void;
-    onConfirm: () => void;
+    onConfirm: (notes: string) => void;
+    initialNotes?: string;
     loading?: boolean;
 };
 
@@ -23,8 +24,14 @@ export default function EndEventModal({
     eventTitle,
     onCancel,
     onConfirm,
+    initialNotes,
     loading = false,
 }: Props) {
+    const [notes, setNotes] = useState(initialNotes ?? "");
+    useEffect(() => {
+        setNotes(initialNotes ?? "");
+    }, [initialNotes]);
+
     return (
         <Modal
             visible={visible}
@@ -53,7 +60,7 @@ export default function EndEventModal({
                             styles.confirmBtn,
                             loading && styles.confirmBtnDisabled,
                         ]}
-                        onPress={onConfirm}
+                        onPress={() => onConfirm(notes)}
                         disabled={loading}>
                         {loading ? (
                             <ActivityIndicator color="#fff" />

--- a/frontend/components/ui/trail-event-header.tsx
+++ b/frontend/components/ui/trail-event-header.tsx
@@ -76,9 +76,7 @@ export default function TrailEventHeader({
     const handleConfirmEnd = async (notes?: string) => {
         setStopping(true);
         try {
-            if (notes && notes.trim() !== "") {
-                await saveDraft(event.eventId, notes);
-            }
+            await saveDraft(event.eventId, notes?.trim() ?? "");
             await setEventInactive(event.eventId);
             setEndModalVisible(false);
             onStop?.();

--- a/frontend/components/ui/trail-event-header.tsx
+++ b/frontend/components/ui/trail-event-header.tsx
@@ -1,6 +1,6 @@
 import { Palette } from "@/constants/theme";
 import type { Event } from "@/services/event-service";
-import { setEventInactive } from "@/services/event-service";
+import { saveDraft, setEventInactive } from "@/services/event-service";
 import { fetchCardUrl } from "@/services/trello-service";
 import { MaterialIcons } from "@expo/vector-icons";
 import { Square } from "lucide-react-native";
@@ -22,6 +22,7 @@ const API_KEY = process.env.EXPO_PUBLIC_TRELLO_API_KEY ?? "";
 interface TrailEventHeaderProps {
     event: Event;
     onStop?: () => void;
+    notes?: string;
     variant?: "default" | "document" | "summary";
 }
 
@@ -35,6 +36,7 @@ function formatDuration(seconds: number): string {
 export default function TrailEventHeader({
     event,
     onStop,
+    notes,
     variant = "default",
 }: TrailEventHeaderProps) {
     const insets = useSafeAreaInsets();
@@ -71,9 +73,12 @@ export default function TrailEventHeader({
         setEndModalVisible(true);
     };
 
-    const handleConfirmEnd = async () => {
+    const handleConfirmEnd = async (notes?: string) => {
         setStopping(true);
         try {
+            if (notes && notes.trim() !== "") {
+                await saveDraft(event.eventId, notes);
+            }
             await setEventInactive(event.eventId);
             setEndModalVisible(false);
             onStop?.();
@@ -222,6 +227,7 @@ export default function TrailEventHeader({
                 <EndEventModal
                     visible={endModalVisible}
                     eventTitle={event.title}
+                    initialNotes={notes ?? ""}
                     onCancel={() => setEndModalVisible(false)}
                     onConfirm={handleConfirmEnd}
                     loading={stopping}
@@ -268,6 +274,7 @@ export default function TrailEventHeader({
             <EndEventModal
                 visible={endModalVisible}
                 eventTitle={event.title}
+                initialNotes={notes ?? ""}
                 onCancel={() => setEndModalVisible(false)}
                 onConfirm={handleConfirmEnd}
                 loading={stopping}

--- a/frontend/services/event-service.ts
+++ b/frontend/services/event-service.ts
@@ -280,6 +280,17 @@ export async function saveDraft(
     });
 }
 
+// Update only the notes field for an event
+export async function updateEventNotes(
+    eventId: string,
+    notes: string,
+): Promise<void> {
+    const db = getFirestore();
+    await updateDoc(doc(db, EVENTS_COLLECTION, eventId), {
+        notes,
+    });
+}
+
 // Mark a draft as published (call this after the Trello publish succeeds)
 export async function publishEvent(eventId: string): Promise<void> {
     const db = getFirestore();

--- a/frontend/services/event-service.ts
+++ b/frontend/services/event-service.ts
@@ -1,16 +1,16 @@
 import { auth } from "@/config/firebase";
 import {
-	collection,
-	doc,
-	getDoc,
-	getDocs,
-	getFirestore,
-	orderBy,
-	query,
-	Timestamp,
-	updateDoc,
-	where,
-	writeBatch,
+    collection,
+    doc,
+    getDoc,
+    getDocs,
+    getFirestore,
+    orderBy,
+    query,
+    Timestamp,
+    updateDoc,
+    where,
+    writeBatch,
 } from "firebase/firestore";
 
 // per event metrics collected during trail event
@@ -93,7 +93,6 @@ export interface Event {
     toolHaulers: string;
     gloverLover: string;
     notes: string;
-    notepad?: string;
     publishedAt?: Timestamp;
     metrics?: EventMetrics;
 }
@@ -269,7 +268,7 @@ export async function setEventInactive(eventId: string): Promise<void> {
 // Save a completed event as a draft instead of immediately publishing
 export async function saveDraft(
     eventId: string,
-    notepad?: string,
+    notes?: string,
 ): Promise<void> {
     const db = getFirestore();
     await updateDoc(doc(db, EVENTS_COLLECTION, eventId), {
@@ -277,7 +276,7 @@ export async function saveDraft(
         isActive: false,
         endDate: Timestamp.now(),
         savedAsDraftAt: Timestamp.now(),
-        ...(notepad !== undefined ? { notepad } : {}),
+        ...(notes !== undefined ? { notes } : {}),
     });
 }
 
@@ -316,5 +315,5 @@ export function extractMetricsWithHours(event: Event): EventMetricsWithHours {
                 ).toFixed(1),
             );
         })(),
-    }
-};
+    };
+}

--- a/frontend/services/trello-service.ts
+++ b/frontend/services/trello-service.ts
@@ -112,7 +112,9 @@ export async function fetchUpcomingEvents(
     return Promise.all(
         cards.map(async (card) => {
             const imgAttachmentUrl = getFirstImageAttachment(card.attachments);
-			const imageUrl = imgAttachmentUrl ? await trello.loadTrelloImage(imgAttachmentUrl) : null;
+            const imageUrl = imgAttachmentUrl
+                ? await trello.loadTrelloImage(imgAttachmentUrl)
+                : null;
             const parsed = parseEventDescription(card.desc ?? "");
             return {
                 id: card.id,
@@ -120,19 +122,23 @@ export async function fetchUpcomingEvents(
                 description: card.desc ?? "",
                 date: card.eventDate,
                 imageUrl,
-                ...parsed
+                ...parsed,
             };
         }),
     );
 }
 
 // finds the first image (not trello card or other) attached to a card to display with it
-function getFirstImageAttachment(attachments: TrelloAttachment[] | undefined): string | null {
-	if (!attachments || attachments.length === 0) return null;
+function getFirstImageAttachment(
+    attachments: TrelloAttachment[] | undefined,
+): string | null {
+    if (!attachments || attachments.length === 0) return null;
 
-	const pattern = /image/;
-	const img = attachments.find((attachment) => pattern.exec(attachment.mimeType));
-	return img?.url ?? null;
+    const pattern = /image/;
+    const img = attachments.find((attachment) =>
+        pattern.exec(attachment.mimeType),
+    );
+    return img?.url ?? null;
 }
 
 // creates a new event card in the Scheduled Events list with the card name prefixed with date
@@ -214,5 +220,33 @@ export async function addAlbumLinkToCard(
         replacedDescription = currentDescription + newLinkText;
     }
 
+    await trello.replaceCardDescription(cardID, replacedDescription);
+}
+
+// adds notes to a trello event card description
+export async function addNotesToCard(
+    cardID: string,
+    notes: string,
+    key: string,
+): Promise<void> {
+    const trello = new TrelloClient(key);
+    const card = await trello.getCard(cardID);
+    const currentDescription = card.desc ?? "";
+
+    const notesPattern = /\n\n📝 Notes:.*?(?=\n\n📷 Album Link:|$)/s;
+    const newNotesText = `\n\n📝 Notes:\n${notes}`;
+
+    let replacedDescription: string;
+    if (notesPattern.test(currentDescription)) {
+        // replace existing notes to make operation idempotent
+        // note: this makes the assumption that notes are followed by the album link
+        replacedDescription = currentDescription.replace(
+            notesPattern,
+            newNotesText,
+        );
+    } else {
+        // append new notes if none exists
+        replacedDescription = currentDescription + newNotesText;
+    }
     await trello.replaceCardDescription(cardID, replacedDescription);
 }

--- a/frontend/services/trello-service.ts
+++ b/frontend/services/trello-service.ts
@@ -234,10 +234,13 @@ export async function addNotesToCard(
     const currentDescription = card.desc ?? "";
 
     const notesPattern = /\n\n📝 Notes:.*?(?=\n\n📷 Album Link:|$)/s;
-    const newNotesText = `\n\n📝 Notes:\n${notes}`;
+    const trimmedNotes = notes.trim();
+    const newNotesText = `\n\n📝 Notes:\n${trimmedNotes}`;
 
     let replacedDescription: string;
-    if (notesPattern.test(currentDescription)) {
+    if (trimmedNotes === "") {
+        replacedDescription = currentDescription;
+    } else if (notesPattern.test(currentDescription)) {
         // replace existing notes to make operation idempotent
         // note: this makes the assumption that notes are followed by the album link
         replacedDescription = currentDescription.replace(

--- a/frontend/services/trello-service.ts
+++ b/frontend/services/trello-service.ts
@@ -277,7 +277,10 @@ export async function addNotesToCard(
     let replacedDescription: string;
     if (trimmedNotes === "") {
         replacedDescription = currentDescription;
-    } else if (notesPattern.test(currentDescription)) {
+    } else if (
+        currentDescription.includes("📷 Album Link:") &&
+        notesPattern.test(currentDescription)
+    ) {
         // replace existing notes to make operation idempotent
         // note: this makes the assumption that notes are followed by the album link
         replacedDescription = currentDescription.replace(
@@ -285,7 +288,7 @@ export async function addNotesToCard(
             newNotesText,
         );
     } else {
-        // append new notes if none exists
+        // append new notes if none exists or if notes exist but there is no album link (position is unknown so just append to end)
         replacedDescription = currentDescription + newNotesText;
     }
     await trello.replaceCardDescription(cardID, replacedDescription);

--- a/frontend/services/trello-service.ts
+++ b/frontend/services/trello-service.ts
@@ -275,9 +275,7 @@ export async function addNotesToCard(
     const newNotesText = `\n\n📝 Notes:\n${trimmedNotes}`;
 
     let replacedDescription: string;
-    if (trimmedNotes === "") {
-        replacedDescription = currentDescription;
-    } else if (
+    if (
         currentDescription.includes("📷 Album Link:") &&
         notesPattern.test(currentDescription)
     ) {


### PR DESCRIPTION
## task assigned
- figure out where event notes go when the event is published
- merge notepad and notes into one field in Firebase
## code changes
- merged instances of notepad into notes (notepad not being used anymore)
- created function for updating notes in the Trello description
  - notes are set initially when creating the event and if they are updated the changes will show in the Trello event card description
- updated draft saving logic to also save event leader, zone leaders, tool leaders, and glove lover to the Trello description
- updated routing starting from the trail event header to the edit draft page to persist the notes
## issues closed
- addresses #47 
## test plan
- created a new event with notes
- started the event, updated notes, then stopped the event
- observed that the updated notes persist through the modals and make it to the final screen and are pushed to Trello


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional end-event notes: users can enter notes when ending an event; notes are saved, shown on the event summary, and forwarded into draft/edit flows.
  * Notes are added to linked Trello cards and included alongside event roles/work-scope in the card description.

* **Refactor**
  * Unified notepad → notes across drafts, editors, headers, navigation, and saving/publishing flows for consistent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->