### PR TITLE
Remove navbar while event is active + on summary screen

### DIFF
--- a/frontend/app/event-summary.tsx
+++ b/frontend/app/event-summary.tsx
@@ -1,4 +1,3 @@
-import BottomNav from "@/components/ui/bottom-nav";
 import HomeHeader from "@/components/ui/header";
 import TrailEventHeader from "@/components/ui/trail-event-header";
 import type { Event, EventMetricsWithHours } from "@/services/event-service";
@@ -411,16 +410,24 @@ export default function EventSummaryScreen() {
                     <Pressable
                         style={styles.actionCard}
                         onPress={() => router.replace("/home-screen")}>
+                        <View style={styles.actionIconWrap}>
+                            <MaterialCommunityIcons
+                                name="home-outline"
+                                size={24}
+                                color="#666"
+                            />
+                        </View>
                         <View style={{ flex: 1 }}>
                             <Text style={styles.actionCardTitle}>
                                 Back to home screen
+                            </Text>
+                            <Text style={styles.actionCardSubtitle}>
+                                Return to the main menu
                             </Text>
                         </View>
                     </Pressable>
                 )}
             </ScrollView>
-
-            <BottomNav />
         </View>
     );
 }

--- a/frontend/app/trail-document-screen.tsx
+++ b/frontend/app/trail-document-screen.tsx
@@ -1,4 +1,3 @@
-import BottomNav from "@/components/ui/bottom-nav";
 import HomeHeader from "@/components/ui/header";
 import { TrailDocIssuesCard } from "@/components/ui/trail-doc-issues-card";
 import TrailEventHeader from "@/components/ui/trail-event-header";
@@ -290,7 +289,6 @@ export default function TrailDocumentScreen() {
 
                     </View>
                 </ScrollView>
-                <BottomNav />
             </View>
 
         </>


### PR DESCRIPTION
## task assigned
- while on the event active trail document and summary screens, the user could navigate away using the sidebar and would not be able to go back to those screens, remove the navbar for these screens
## code changes
- lowkey just a one liner to get rid of the navbar component lol
- also made the back to home button on the summary screen match the other buttons
## issues closed
- Close #54 
## screenshots + videos
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-05-07 at 00 50 14" src="https://github.com/user-attachments/assets/5eb8d88a-5742-445d-8da3-9f2c1c33f665" />


<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-05-07 at 00 56 09" src="https://github.com/user-attachments/assets/ef3bd1ca-233f-46f8-96f4-4ff995a3d23e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Back to home screen" action card to the event summary screen for convenient navigation back to the main menu

* **Refactor**
  * Removed bottom navigation component from the trail document screen

<!-- end of auto-generated comment: release notes by coderabbit.ai -->