### PR TITLE
edit issue draft (closes issue #77)

### DIFF
--- a/frontend/app/edit-draft.tsx
+++ b/frontend/app/edit-draft.tsx
@@ -15,8 +15,8 @@ import {
 } from "@/services/trello-service";
 import { TrailDocumentIssueItem } from "@/types/trail-types";
 import { Ionicons } from "@expo/vector-icons";
-import { useLocalSearchParams, useRouter } from "expo-router";
-import React, { useEffect, useState } from "react";
+import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
     ActivityIndicator,
     Alert,
@@ -33,6 +33,14 @@ const API_KEY = process.env.EXPO_PUBLIC_TRELLO_API_KEY;
 export default function EditDraftScreen() {
     const router = useRouter();
     const { eventId } = useLocalSearchParams<{ eventId: string }>();
+
+    const pressedIssueRef = useRef(false);
+    const [refreshKey, setRefreshKey] = useState(0);
+
+    useFocusEffect(useCallback(() => {
+        pressedIssueRef.current = false;
+        setRefreshKey((k) => k + 1);
+    }, []));
 
     const [event, setEvent] = useState<Event>();
     const [loading, setLoading] = useState(true);
@@ -96,7 +104,7 @@ export default function EditDraftScreen() {
         return () => {
             cancelled = true;
         };
-    }, [event]);
+    }, [event, refreshKey]);
 
     const handleSaveDraft = async () => {
         if (!event || savingDraft || publishing) return;
@@ -161,6 +169,21 @@ export default function EditDraftScreen() {
                                 name={issue.name}
                                 date={issue.creationDate}
                                 imageUrl={issue.imageUrl}
+                                onPress={() => {
+                                    if (pressedIssueRef.current) return;
+                                    pressedIssueRef.current = true;
+                                    router.push({
+                                        pathname: "/trail-issue-screen",
+                                        params: {
+                                            issueId: issue.id,
+                                            issueName: issue.name,
+                                            imageUrl: issue.imageUrl ?? undefined,
+                                            description: (issue as any).description,
+                                            eventId: event.eventId,
+                                            isDraft: "true",
+                                        },
+                                    });
+                                }}
                             />
                         ))}
                         {!issuesError && issues.length === 0 && (

--- a/frontend/app/trail-issue-screen.tsx
+++ b/frontend/app/trail-issue-screen.tsx
@@ -29,6 +29,7 @@ export default function TrailIssueDetailScreen() {
         description,
         eventId,
         isNew,
+        isDraft,
         beforeImageUri,
         afterImageUri,
     } = useLocalSearchParams<{
@@ -38,6 +39,7 @@ export default function TrailIssueDetailScreen() {
         description?: string;
         eventId?: string;
         isNew?: string;
+        isDraft?: string;
         beforeImageUri?: string;
         afterImageUri?: string;
     }>();
@@ -165,30 +167,39 @@ export default function TrailIssueDetailScreen() {
         });
     };
 
-    const PhotoCard = ({ slot, label }: { slot: PhotoSlot; label: string }) => (
-        <TouchableOpacity
-            style={styles.photoCard}
-            onPress={() => handlePhotoPress(slot)}
-            activeOpacity={0.75}
-            accessibilityLabel={`${label} photo`}
-            accessibilityRole="button">
-            {photos[slot] ? (
+    const PhotoCard = ({ slot, label }: { slot: PhotoSlot; label: string }) => {
+        const photosLocked = isDraft === "true";
+        const content = photos[slot] ? (
+            <Image
+                source={{ uri: photos[slot] as string }}
+                style={styles.photoImage}
+                resizeMode="cover"
+            />
+        ) : (
+            <View style={styles.photoPlaceholder}>
                 <Image
-                    source={{ uri: photos[slot] as string }}
-                    style={styles.photoImage}
-                    resizeMode="cover"
+                    source={require("../assets/images/camera-purple.png")}
+                    style={[styles.cameraIcon, photosLocked && { opacity: 0.4 }]}
                 />
-            ) : (
-                <View style={styles.photoPlaceholder}>
-                    <Image
-                        source={require("../assets/images/camera-purple.png")}
-                        style={styles.cameraIcon}
-                    />
-                    <Text style={styles.photoLabel}>{label}</Text>
-                </View>
-            )}
-        </TouchableOpacity>
-    );
+                <Text style={[styles.photoLabel, photosLocked && { color: "#bbb" }]}>{label}</Text>
+            </View>
+        );
+
+        if (photosLocked) {
+            return <View style={styles.photoCard}>{content}</View>;
+        }
+
+        return (
+            <TouchableOpacity
+                style={styles.photoCard}
+                onPress={() => handlePhotoPress(slot)}
+                activeOpacity={0.75}
+                accessibilityLabel={`${label} photo`}
+                accessibilityRole="button">
+                {content}
+            </TouchableOpacity>
+        );
+    };
 
     return (
         <View style={styles.screen}>


### PR DESCRIPTION
## task assigned
allows the user to edit issues inside of drafts
## code changes
added isDraft to the edit issue page to allow the user to edit the name, notes, and metrics of an issue, but does not allow them to upload a new photo
refreshes draft page on return from issue page so that the edited issue can be seen.
## issues closed
closes issue #77
## test plan
- i tested editing and saving issues inside of drafts and checking if they reflected on trello

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Draft editor automatically refreshes trail issues when you return to the screen
  * Double-tap safeguard prevents accidental duplicate navigation when opening issues
  * Draft view now locks photo cards in read-only mode with reduced visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->