### PR TITLE
Bugfix Refresh After Event Creation

### DIFF
--- a/frontend/app/home-screen.tsx
+++ b/frontend/app/home-screen.tsx
@@ -2,6 +2,7 @@ import BottomNav from "@/components/ui/bottom-nav";
 import CreateNewEvent from "@/components/ui/create-new-event";
 import Header from "@/components/ui/header";
 import MakeBeforeAfterGraphic from "@/components/ui/make-graphic";
+import { PastEventsCard } from "@/components/ui/past-events-card";
 import TakeAfterPicture from "@/components/ui/take-after-picture";
 import TrailEventCard from "@/components/ui/trail-event-card";
 import TrelloLoginUI from "@/components/ui/trello-login";
@@ -9,12 +10,11 @@ import {
     UpcomingEventsCard,
     type UpcomingEventItem,
 } from "@/components/ui/upcoming-events-card";
-import { PastEventsCard } from "@/components/ui/past-events-card";
-import { fetchEventCards } from "@/services/trello-service";
 import { useIsAdmin } from "@/hooks/use-is-admin";
 import { useTrelloAuth } from "@/hooks/use-trello-auth";
 import { getEventByTrelloCardId, startEvent } from "@/services/event-service";
-import { Stack, useRouter, useFocusEffect } from "expo-router";
+import { fetchEventCards } from "@/services/trello-service";
+import { Stack, useFocusEffect, useRouter } from "expo-router";
 import React, { useCallback, useState } from "react";
 import { Alert, ScrollView, StyleSheet, View } from "react-native";
 
@@ -22,7 +22,13 @@ const API_KEY = process.env.EXPO_PUBLIC_TRELLO_API_KEY;
 
 export default function HomeScreen() {
     const router = useRouter();
-    const { isAuthenticated, promptSignIn, loading, initializing, error: trelloError } = useTrelloAuth();
+    const {
+        isAuthenticated,
+        promptSignIn,
+        loading,
+        initializing,
+        error: trelloError,
+    } = useTrelloAuth();
     const [events, setEvents] = useState<UpcomingEventItem[]>([]);
     const [eventsLoading, setEventsLoading] = useState(true);
     const [eventsError, setEventsError] = useState<string | null>(null);
@@ -38,12 +44,13 @@ export default function HomeScreen() {
         if (ok) {
             router.replace("/home-screen");
         }
-    }
+    };
 
     useFocusEffect(
         useCallback(() => {
             if (!isAuthenticated || !API_KEY) {
                 setEventsLoading(false);
+                setPastEventsLoading(false);
                 return;
             }
             setEventsLoading(true);
@@ -56,7 +63,7 @@ export default function HomeScreen() {
                 .then(setPastEvents)
                 .catch((e) => setPastEventsError(e.message))
                 .finally(() => setPastEventsLoading(false));
-        }, [isAuthenticated])
+        }, [isAuthenticated]),
     );
 
     if (!isAuthenticated) {
@@ -66,12 +73,14 @@ export default function HomeScreen() {
                 isLoading={loading || initializing}
                 errorMessage={trelloError?.message ?? null}
             />
-        )
+        );
     }
 
     const handlePressEvent = async (event: UpcomingEventItem) => {
         setSelectedEvent(event);
-        const firebaseEvent = await getEventByTrelloCardId(event.id).catch(() => null);
+        const firebaseEvent = await getEventByTrelloCardId(event.id).catch(
+            () => null,
+        );
         if (!firebaseEvent) return;
 
         setSelectedEvent((prev) => {
@@ -89,26 +98,31 @@ export default function HomeScreen() {
 
     const handleStartEvent = async (event: UpcomingEventItem) => {
         try {
-			// set startDate in firebase
+            // set startDate in firebase
             await startEvent(event.id);
-			// close modal
+            // close modal
             setSelectedEvent(null);
-			// go to in progress screen
-			const firebaseEvent = await getEventByTrelloCardId(event.id).catch(() => null);
-			if (firebaseEvent) {
-				router.push({
-					pathname: "/trail-document-screen",
-					params: { eventId: firebaseEvent.eventId },
-				});
-			} else {
-				Alert.alert("Not available", "This event hasn't been set up in the app yet.");
-			}
+            // go to in progress screen
+            const firebaseEvent = await getEventByTrelloCardId(event.id).catch(
+                () => null,
+            );
+            if (firebaseEvent) {
+                router.push({
+                    pathname: "/trail-document-screen",
+                    params: { eventId: firebaseEvent.eventId },
+                });
+            } else {
+                Alert.alert(
+                    "Not available",
+                    "This event hasn't been set up in the app yet.",
+                );
+            }
         } catch (error) {
             const message =
                 error instanceof Error
                     ? error.message
                     : "Failed to start event";
-			// close modal
+            // close modal
             setSelectedEvent(null);
             Alert.alert("Error", message);
         }
@@ -124,13 +138,14 @@ export default function HomeScreen() {
                     showsVerticalScrollIndicator={false}>
                     <Header showGreeting />
                     <View style={styles.cardWrapper}>
-                        <TakeAfterPicture onPress={() => router.push({
-                            pathname: "/camera-view",
-                            params: { mode: 'after' }
-                        })} />
-                        <MakeBeforeAfterGraphic onPress={() => router.push("/before-after-graphic")} />
+                        <TakeAfterPicture />
+                        <MakeBeforeAfterGraphic
+                            onPress={() => router.push("/before-after-graphic")}
+                        />
                         {isAdmin && (
-                            <CreateNewEvent onPress={() => router.push("/setup-event")} />
+                            <CreateNewEvent
+                                onPress={() => router.push("/setup-event")}
+                            />
                         )}
                     </View>
                     <View style={styles.eventsSection}>

--- a/frontend/app/home-screen.tsx
+++ b/frontend/app/home-screen.tsx
@@ -14,8 +14,8 @@ import { fetchEventCards } from "@/services/trello-service";
 import { useIsAdmin } from "@/hooks/use-is-admin";
 import { useTrelloAuth } from "@/hooks/use-trello-auth";
 import { getEventByTrelloCardId, startEvent } from "@/services/event-service";
-import { Stack, useRouter } from "expo-router";
-import React, { useEffect, useState } from "react";
+import { Stack, useRouter, useFocusEffect } from "expo-router";
+import React, { useCallback, useState } from "react";
 import { Alert, ScrollView, StyleSheet, View } from "react-native";
 
 const API_KEY = process.env.EXPO_PUBLIC_TRELLO_API_KEY;
@@ -40,21 +40,24 @@ export default function HomeScreen() {
         }
     }
 
-    useEffect(() => {
-        if (!isAuthenticated || !API_KEY) {
-            setEventsLoading(false);
-            return;
-        }
-        setEventsLoading(true);
-        fetchEventCards(API_KEY, "upcoming")
-            .then(setEvents)
-            .catch((e) => setEventsError(e.message))
-            .finally(() => setEventsLoading(false));
-        fetchEventCards(API_KEY, "past")
-            .then(setPastEvents)
-            .catch((e) => setPastEventsError(e.message))
-            .finally(() => setPastEventsLoading(false));
-    }, [isAuthenticated]);
+    useFocusEffect(
+        useCallback(() => {
+            if (!isAuthenticated || !API_KEY) {
+                setEventsLoading(false);
+                return;
+            }
+            setEventsLoading(true);
+            setPastEventsLoading(true);
+            fetchEventCards(API_KEY, "upcoming")
+                .then(setEvents)
+                .catch((e) => setEventsError(e.message))
+                .finally(() => setEventsLoading(false));
+            fetchEventCards(API_KEY, "past")
+                .then(setPastEvents)
+                .catch((e) => setPastEventsError(e.message))
+                .finally(() => setPastEventsLoading(false));
+        }, [isAuthenticated])
+    );
 
     if (!isAuthenticated) {
         return (
@@ -121,7 +124,10 @@ export default function HomeScreen() {
                     showsVerticalScrollIndicator={false}>
                     <Header showGreeting />
                     <View style={styles.cardWrapper}>
-                        <TakeAfterPicture />
+                        <TakeAfterPicture onPress={() => router.push({
+                            pathname: "/camera-view",
+                            params: { mode: 'after' }
+                        })} />
                         <MakeBeforeAfterGraphic onPress={() => router.push("/before-after-graphic")} />
                         {isAdmin && (
                             <CreateNewEvent onPress={() => router.push("/setup-event")} />


### PR DESCRIPTION
## task assigned
- Upcoming Events on home screen should refresh after an event is created by the user or another user
## code changes
- `home-screen.tsx` updated the fetch events to refresh so newly created events will be shown 
## issues closed
- Closes #74
## screenshots + videos
- video: https://drive.google.com/file/d/1e5Twh4-jAXG0d5ospke7BDhI_vSSIIR5/view?usp=sharing
## test plan
- tested creating an event and then seeing in the home screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event cards now load reliably when the home screen comes into focus
  * Authentication validation prevents unnecessary API calls when credentials are missing

* **Improvements**
  * Camera functionality now navigates to a dedicated camera view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->