### PR TITLE
added resume logic if a user was the one to start an event (closes issue #55)

### DIFF
--- a/frontend/app/event-summary.tsx
+++ b/frontend/app/event-summary.tsx
@@ -376,7 +376,11 @@ export default function EventSummaryScreen() {
                         saving && styles.actionCardDisabled,
                     ]}
                     onPress={async () => {
-                        await clearActiveEventLocally();
+                        try {
+                            await clearActiveEventLocally();
+                        } catch (error) {
+                            setError((error as Error).message);
+                        }
                         router.replace({
                             pathname: "/edit-draft",
                             params: { eventId },

--- a/frontend/app/event-summary.tsx
+++ b/frontend/app/event-summary.tsx
@@ -3,7 +3,8 @@ import HomeHeader from "@/components/ui/header";
 import TrailEventHeader from "@/components/ui/trail-event-header";
 import type { Event, EventMetricsWithHours } from "@/services/event-service";
 import {
-	extractMetricsWithHours,
+    clearActiveEventLocally,
+    extractMetricsWithHours,
     getEventById,
     saveDraft,
 } from "@/services/event-service";
@@ -99,13 +100,13 @@ const METRIC_DEFS: MetricDef[] = [
         icon: "shield-check-outline",
         color: BLUE,
     },
-	{
-		key: "snowRemovalEvents",
-		label: "Snow removal",
-		sublabel: "# of removal events",
-		icon: "snowflake",
-		color: PURPLE
-	},
+    {
+        key: "snowRemovalEvents",
+        label: "Snow removal",
+        sublabel: "# of removal events",
+        icon: "snowflake",
+        color: PURPLE,
+    },
     {
         key: "potholesFilled",
         label: "Potholes",
@@ -113,13 +114,13 @@ const METRIC_DEFS: MetricDef[] = [
         icon: "road-variant",
         color: TEAL,
     },
-	{
-		key: "trailEdgedFeet",
-		label: "Trail edging",
-		sublabel: "ft of edging improved",
-		icon: "scissors-cutting",
-		color: BLUE
-	},
+    {
+        key: "trailEdgedFeet",
+        label: "Trail edging",
+        sublabel: "ft of edging improved",
+        icon: "scissors-cutting",
+        color: BLUE,
+    },
     {
         key: "trashBagsCollected",
         label: "Trash bags",
@@ -127,7 +128,7 @@ const METRIC_DEFS: MetricDef[] = [
         icon: "trash-can-outline",
         color: PURPLE,
     },
-	{
+    {
         key: "trashPoundsCollected",
         label: "Trash weight",
         sublabel: "# of lbs collected",
@@ -148,19 +149,19 @@ const METRIC_DEFS: MetricDef[] = [
         icon: "leaf-circle-outline",
         color: PURPLE,
     },
-	{
+    {
         key: "hoursOfService",
         label: "Hours of service",
         sublabel: "hrs",
         icon: "clock-outline",
         color: TEAL,
-    }
+    },
 ];
 interface MetricGridCardProps {
     def: MetricDef;
     value: number | string;
     delay: number;
-};
+}
 
 function MetricGridCard({ def, value, delay }: MetricGridCardProps) {
     const opacity = useRef(new Animated.Value(0)).current;
@@ -259,15 +260,16 @@ export default function EventSummaryScreen() {
 
     const stats = extractMetricsWithHours(event);
 
-    const visibleMetrics = stats ? METRIC_DEFS.filter(
-        (def) => (stats[def.key] as number) !== 0,
-    ) : [];
+    const visibleMetrics = stats
+        ? METRIC_DEFS.filter((def) => (stats[def.key] as number) !== 0)
+        : [];
 
     const handleSaveDraft = async () => {
         if (saving || savedDraft || savedTrello) return;
         setSaving(true);
         try {
             await saveDraft(eventId, notepad);
+            await clearActiveEventLocally();
             setSavedDraft(true);
         } catch {
             Alert.alert("Error", "Could not save event to drafts.");
@@ -373,12 +375,13 @@ export default function EventSummaryScreen() {
                         savedTrello && styles.actionCardSaved,
                         saving && styles.actionCardDisabled,
                     ]}
-                    onPress={() => router.replace({
-						pathname: "/edit-draft",
-						params: {
-							eventId
-						}
-					})}
+                    onPress={async () => {
+                        await clearActiveEventLocally();
+                        router.replace({
+                            pathname: "/edit-draft",
+                            params: { eventId },
+                        });
+                    }}
                     disabled={saving || savedDraft || savedTrello}>
                     <View style={styles.actionIconWrap}>
                         {saving ? (

--- a/frontend/app/home-screen.tsx
+++ b/frontend/app/home-screen.tsx
@@ -78,9 +78,13 @@ export default function HomeScreen() {
             if (!storedId) return;
 
             // verify it's still active in Firestore
-            const firebaseEvent = await getEventByTrelloCardId(storedId).catch(
-                () => null,
-            );
+            let firebaseEvent;
+            try {
+                firebaseEvent = await getEventByTrelloCardId(storedId);
+            } catch {
+                Alert.alert("Error", "Error getting active event data.");
+                return;
+            }
             if (
                 firebaseEvent &&
                 firebaseEvent.startDate &&

--- a/frontend/app/home-screen.tsx
+++ b/frontend/app/home-screen.tsx
@@ -2,6 +2,7 @@ import BottomNav from "@/components/ui/bottom-nav";
 import CreateNewEvent from "@/components/ui/create-new-event";
 import Header from "@/components/ui/header";
 import MakeBeforeAfterGraphic from "@/components/ui/make-graphic";
+import { PastEventsCard } from "@/components/ui/past-events-card";
 import TakeAfterPicture from "@/components/ui/take-after-picture";
 import TrailEventCard from "@/components/ui/trail-event-card";
 import TrelloLoginUI from "@/components/ui/trello-login";
@@ -9,20 +10,30 @@ import {
     UpcomingEventsCard,
     type UpcomingEventItem,
 } from "@/components/ui/upcoming-events-card";
-import { PastEventsCard } from "@/components/ui/past-events-card";
-import { fetchEventCards } from "@/services/trello-service";
 import { useIsAdmin } from "@/hooks/use-is-admin";
 import { useTrelloAuth } from "@/hooks/use-trello-auth";
-import { getEventByTrelloCardId, startEvent } from "@/services/event-service";
+import {
+    clearActiveEventLocally,
+    getEventByTrelloCardId,
+    getLocalActiveEventId,
+    saveActiveEventLocally,
+    startEvent,
+} from "@/services/event-service";
+import { fetchEventCards } from "@/services/trello-service";
 import { Stack, useRouter } from "expo-router";
 import React, { useEffect, useState } from "react";
 import { Alert, ScrollView, StyleSheet, View } from "react-native";
-
 const API_KEY = process.env.EXPO_PUBLIC_TRELLO_API_KEY;
 
 export default function HomeScreen() {
     const router = useRouter();
-    const { isAuthenticated, promptSignIn, loading, initializing, error: trelloError } = useTrelloAuth();
+    const {
+        isAuthenticated,
+        promptSignIn,
+        loading,
+        initializing,
+        error: trelloError,
+    } = useTrelloAuth();
     const [events, setEvents] = useState<UpcomingEventItem[]>([]);
     const [eventsLoading, setEventsLoading] = useState(true);
     const [eventsError, setEventsError] = useState<string | null>(null);
@@ -32,13 +43,16 @@ export default function HomeScreen() {
     const [selectedEvent, setSelectedEvent] =
         useState<UpcomingEventItem | null>(null);
     const isAdmin = useIsAdmin();
+    const [localActiveEventId, setLocalActiveEventId] = useState<string | null>(
+        null,
+    );
 
     const handleTrelloSignIn = async () => {
         const ok = await promptSignIn();
         if (ok) {
             router.replace("/home-screen");
         }
-    }
+    };
 
     useEffect(() => {
         if (!isAuthenticated || !API_KEY) {
@@ -56,6 +70,30 @@ export default function HomeScreen() {
             .finally(() => setPastEventsLoading(false));
     }, [isAuthenticated]);
 
+    useEffect(() => {
+        if (!isAuthenticated) return;
+
+        (async () => {
+            const storedId = await getLocalActiveEventId();
+            if (!storedId) return;
+
+            // verify it's still active in Firestore
+            const firebaseEvent = await getEventByTrelloCardId(storedId).catch(
+                () => null,
+            );
+            if (
+                firebaseEvent &&
+                firebaseEvent.startDate &&
+                !firebaseEvent.endDate
+            ) {
+                setLocalActiveEventId(storedId);
+            } else {
+                // stale — clean it up
+                await clearActiveEventLocally();
+            }
+        })();
+    }, [isAuthenticated]);
+
     if (!isAuthenticated) {
         return (
             <TrelloLoginUI
@@ -63,12 +101,14 @@ export default function HomeScreen() {
                 isLoading={loading || initializing}
                 errorMessage={trelloError?.message ?? null}
             />
-        )
+        );
     }
 
     const handlePressEvent = async (event: UpcomingEventItem) => {
         setSelectedEvent(event);
-        const firebaseEvent = await getEventByTrelloCardId(event.id).catch(() => null);
+        const firebaseEvent = await getEventByTrelloCardId(event.id).catch(
+            () => null,
+        );
         if (!firebaseEvent) return;
 
         setSelectedEvent((prev) => {
@@ -85,27 +125,36 @@ export default function HomeScreen() {
     };
 
     const handleStartEvent = async (event: UpcomingEventItem) => {
+        const isResume = event.id === localActiveEventId;
         try {
-			// set startDate in firebase
-            await startEvent(event.id);
-			// close modal
+            // set startDate in firebase
+            if (!isResume) {
+                await startEvent(event.id);
+                await saveActiveEventLocally(event.id);
+            }
+            // close modal
             setSelectedEvent(null);
-			// go to in progress screen
-			const firebaseEvent = await getEventByTrelloCardId(event.id).catch(() => null);
-			if (firebaseEvent) {
-				router.push({
-					pathname: "/trail-document-screen",
-					params: { eventId: firebaseEvent.eventId },
-				});
-			} else {
-				Alert.alert("Not available", "This event hasn't been set up in the app yet.");
-			}
+            // go to in progress screen
+            const firebaseEvent = await getEventByTrelloCardId(event.id).catch(
+                () => null,
+            );
+            if (firebaseEvent) {
+                router.push({
+                    pathname: "/trail-document-screen",
+                    params: { eventId: firebaseEvent.eventId },
+                });
+            } else {
+                Alert.alert(
+                    "Not available",
+                    "This event hasn't been set up in the app yet.",
+                );
+            }
         } catch (error) {
             const message =
                 error instanceof Error
                     ? error.message
                     : "Failed to start event";
-			// close modal
+            // close modal
             setSelectedEvent(null);
             Alert.alert("Error", message);
         }
@@ -122,9 +171,13 @@ export default function HomeScreen() {
                     <Header showGreeting />
                     <View style={styles.cardWrapper}>
                         <TakeAfterPicture />
-                        <MakeBeforeAfterGraphic onPress={() => router.push("/before-after-graphic")} />
+                        <MakeBeforeAfterGraphic
+                            onPress={() => router.push("/before-after-graphic")}
+                        />
                         {isAdmin && (
-                            <CreateNewEvent onPress={() => router.push("/setup-event")} />
+                            <CreateNewEvent
+                                onPress={() => router.push("/setup-event")}
+                            />
                         )}
                     </View>
                     <View style={styles.eventsSection}>
@@ -135,6 +188,7 @@ export default function HomeScreen() {
                             maxItems={3}
                             onShowMore={() => {}}
                             onPressItem={(event) => handlePressEvent(event)}
+                            activeEventId={localActiveEventId}
                         />
                     </View>
                     <View style={styles.eventsSection}>
@@ -153,6 +207,7 @@ export default function HomeScreen() {
                     visible={selectedEvent !== null}
                     onClose={() => setSelectedEvent(null)}
                     onStartEvent={handleStartEvent}
+                    isResume={selectedEvent?.id === localActiveEventId}
                 />
             </View>
         </>

--- a/frontend/components/ui/trail-event-card.tsx
+++ b/frontend/components/ui/trail-event-card.tsx
@@ -13,6 +13,7 @@ interface TrailEventCardProps {
     visible: boolean;
     onClose: () => void;
     onStartEvent: (event: UpcomingEventItem) => void;
+    isResume?: boolean;
 }
 
 export default function TrailEventCard({
@@ -20,6 +21,7 @@ export default function TrailEventCard({
     visible,
     onClose,
     onStartEvent,
+    isResume = false,
 }: TrailEventCardProps) {
     const [showConfirmation, setShowConfirmation] = useState(false);
 
@@ -113,7 +115,11 @@ export default function TrailEventCard({
                                 styles.startButton,
                                 pressed && styles.startButtonPressed,
                             ]}
-                            onPress={() => setShowConfirmation(true)}>
+                            onPress={() =>
+                                isResume
+                                    ? onStartEvent(event)
+                                    : setShowConfirmation(true)
+                            }>
                             <Play
                                 size={16}
                                 color="#FFFFFF"
@@ -121,7 +127,7 @@ export default function TrailEventCard({
                                 style={styles.playIcon}
                             />
                             <Text style={styles.startButtonText}>
-                                Start Event
+                                {isResume ? "Resume Event" : "Start Event"}
                             </Text>
                         </Pressable>
                     </View>

--- a/frontend/components/ui/upcoming-events-card.tsx
+++ b/frontend/components/ui/upcoming-events-card.tsx
@@ -29,6 +29,7 @@ interface UpcomingEventsCardProps {
     maxItems?: number;
     onShowMore: () => void;
     onPressItem: (event: UpcomingEventItem) => void;
+    activeEventId?: string | null;
 }
 
 const EVENT_STATUS = {
@@ -55,6 +56,7 @@ export function UpcomingEventsCard({
     maxItems = 3,
     onShowMore,
     onPressItem,
+    activeEventId,
 }: UpcomingEventsCardProps) {
     const [expanded, setExpanded] = React.useState(false);
     const hasMore = events.length > maxItems;
@@ -122,17 +124,25 @@ export function UpcomingEventsCard({
                                             styles.tagPill,
                                             {
                                                 backgroundColor:
-                                                    EVENT_STATUS.backgroundColor,
+                                                    event.id === activeEventId
+                                                        ? "#1A7A4A18"
+                                                        : EVENT_STATUS.backgroundColor,
                                             },
                                         ]}>
                                         <Text
                                             style={[
                                                 styles.tagText,
                                                 {
-                                                    color: EVENT_STATUS.color,
+                                                    color:
+                                                        event.id ===
+                                                        activeEventId
+                                                            ? "#1A7A4A"
+                                                            : EVENT_STATUS.color,
                                                 },
                                             ]}>
-                                            {EVENT_STATUS.label}
+                                            {event.id === activeEventId
+                                                ? "In Progress"
+                                                : EVENT_STATUS.label}
                                         </Text>
                                     </View>
                                 </View>

--- a/frontend/services/event-service.ts
+++ b/frontend/services/event-service.ts
@@ -1,16 +1,17 @@
 import { auth } from "@/config/firebase";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import {
-	collection,
-	doc,
-	getDoc,
-	getDocs,
-	getFirestore,
-	orderBy,
-	query,
-	Timestamp,
-	updateDoc,
-	where,
-	writeBatch,
+    collection,
+    doc,
+    getDoc,
+    getDocs,
+    getFirestore,
+    orderBy,
+    query,
+    Timestamp,
+    updateDoc,
+    where,
+    writeBatch,
 } from "firebase/firestore";
 
 // per event metrics collected during trail event
@@ -316,5 +317,21 @@ export function extractMetricsWithHours(event: Event): EventMetricsWithHours {
                 ).toFixed(1),
             );
         })(),
-    }
-};
+    };
+}
+
+const ACTIVE_EVENT_KEY = "active_event_trello_id";
+
+export async function saveActiveEventLocally(
+    trelloCardId: string,
+): Promise<void> {
+    await AsyncStorage.setItem(ACTIVE_EVENT_KEY, trelloCardId);
+}
+
+export async function clearActiveEventLocally(): Promise<void> {
+    await AsyncStorage.removeItem(ACTIVE_EVENT_KEY);
+}
+
+export async function getLocalActiveEventId(): Promise<string | null> {
+    return AsyncStorage.getItem(ACTIVE_EVENT_KEY);
+}


### PR DESCRIPTION
## task assigned
- make it so that if a user who started an event back out to the home page, they are given the ability to resume the event instead of it giving the already started pop up, saves the check locally
## code changes
- mainly just added an active event key that saves when starting an event and functions to get and check it when needed to resume, and locally clear it when the event is over
## issues closed
- Closes #55 
## screenshots + videos
<img width="666" height="1512" alt="image" src="https://github.com/user-attachments/assets/b20445ad-077f-4519-9398-ffdf6374ebc2" />
## test plan
- tested as the user to create and start and event if i back out to the home page if i would be able to restart the same active event

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new metric types to event summaries: Snow removal, Potholes, Trail edging, and Trash weight
  * Added "Resume Event" functionality to continue in-progress trail events
  * Active events now display an "In Progress" status indicator on the home screen
  * Improved event navigation with local state preservation during edits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->