### PR TITLE
Taking after picture button functionality

### DIFF
--- a/frontend/app/camera-view.tsx
+++ b/frontend/app/camera-view.tsx
@@ -148,6 +148,11 @@ export default function CameraViewScreen() {
         } catch (error) {
             console.error('Error saving photo:', error);
         }
+        // When user pressed TakeAfterPicture, no event id
+        if (!eventId) {
+            router.replace('/home-screen');
+            return;
+        }
         if (resolveMode === 'before') {
             router.replace({
                 pathname: '/trail-document-screen',

--- a/frontend/app/home-screen.tsx
+++ b/frontend/app/home-screen.tsx
@@ -178,7 +178,14 @@ export default function HomeScreen() {
                     showsVerticalScrollIndicator={false}>
                     <Header showGreeting />
                     <View style={styles.cardWrapper}>
-                        <TakeAfterPicture />
+                        <TakeAfterPicture
+                            onPress={() =>
+                                router.push({
+                                    pathname: '/camera-view',
+                                    params: { mode: 'after' },
+                                })
+                            }
+                        />
                         <MakeBeforeAfterGraphic
                             onPress={() => router.push("/before-after-graphic")}
                         />


### PR DESCRIPTION
## task assigned
- The `Take After Picture` button has no functionality, make it lead to the camera after picture mode
## code changes
- `camera-view` When the user is taking the after picture and no event id is associated with it, they can choose an overlay photo from their camera roll and once they take a picture, camera-view just short circuits to route the user back to home screen so that photo gets saved and they don't get a "no eventid" error
- - ## issues closed
- Closes #48 
## screenshots + videos
- video: https://drive.google.com/file/d/1DuQ80DZ8M6X8iXcSpnDPFVIP5MnRDgk8/view?usp=drive_link
## test plan
- used ios and android simulator to test taking a picture and then checked the simulator phones camera roll to ensure it was saved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Photo confirmation flow now validates required data before proceeding; users are redirected to home if validation fails.

* **New Features**
  * "Take After Picture" button is now fully functional and navigates to the camera capture screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->