### PR TITLE
frontend: shared error/auth helpers and a single Firestore handle

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,14 @@
+# ---------------------------------------------------------------------------
+# Every EXPO_PUBLIC_* variable is inlined into the shipped JS bundle and is
+# readable by anyone with the app binary. Never put a secret here.
+#
+# These are NOT uploaded to EAS. For cloud builds, create each one as an
+# environment variable in the expo.dev project (preview + production), or
+# builds will ship with undefined config and crash at startup.
+# ---------------------------------------------------------------------------
+
+# Firebase web app config. All seven are required — config/firebase.ts fails
+# fast at startup and names any that are missing.
 EXPO_PUBLIC_FIREBASE_API_KEY=
 EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=
 EXPO_PUBLIC_FIREBASE_PROJECT_ID=
@@ -5,14 +16,28 @@ EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=
 EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=
 EXPO_PUBLIC_FIREBASE_APP_ID=
 EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID=
+
+# Google OAuth clients, used only to sign in to Firebase. The app requests
+# openid/profile/email and nothing more — Google Photos is reached through the
+# backend proxy using the MVT account's own credentials.
 EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=
 EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=
 EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID=
-GOOGLE_REFRESH_TOKEN=
-GOOGLE_CLIENT_SECRET=
-GOOGLE_CLIENT_ID=
-GOOGLE_SPREADSHEET_ID=
+
+# Trello. Only the public API key — each volunteer authorizes with their own
+# per-user OAuth token, held in SecureStore.
 EXPO_PUBLIC_TRELLO_API_KEY=
-EXPO_PUBLIC_TRELLO_API_TOKEN=
-EXPO_PUBLIC_ADMIN_EMAIL=
+
+# Backend photo proxy. Required for albums and photo uploads.
+#   iOS simulator:    http://localhost:8080
+#   Android emulator: http://10.0.2.2:8080
+#   Physical device:  http://<your-LAN-IP>:8080
 EXPO_PUBLIC_BACKEND_URL=
+
+# Trello board and list names. Defaults (shown) point at the mock board; set
+# these to switch to the real MVT board without a code change.
+EXPO_PUBLIC_TRELLO_BOARD_NAME=MVT Mock Board
+EXPO_PUBLIC_TRELLO_TRAIL_ISSUES_LIST=Trail Issues and Problems - Intake
+EXPO_PUBLIC_TRELLO_UPCOMING_EVENTS_LIST=Scheduled Events
+EXPO_PUBLIC_TRELLO_COMPLETED_EVENTS_LIST=Completed Events (From App)
+EXPO_PUBLIC_TRELLO_COMPLETED_ISSUES_LIST=Completed Issues

--- a/frontend/app/auth.tsx
+++ b/frontend/app/auth.tsx
@@ -21,7 +21,7 @@ export default function AuthScreen() {
         if (user) {
             router.replace("/home-screen");
         }
-    }, [user]);
+    }, [user, router]);
 
     const errorMessage = error ? getErrorMessage(error.code) : undefined;
 

--- a/frontend/components/ui/trail-doc-issues-card.tsx
+++ b/frontend/components/ui/trail-doc-issues-card.tsx
@@ -25,7 +25,14 @@ export function TrailDocIssuesCard(issues: Readonly<TrailIssue & { onPress?: () 
 
     return (
         <>
-        <View style={styles.outer}>
+        {/* The whole card is the tap target. Only the 32px chevron used to be
+            pressable, and this card is the sole way into an issue. */}
+        <TouchableOpacity
+            style={styles.outer}
+            activeOpacity={0.7}
+            onPress={issues.onPress}
+            accessibilityRole="button"
+            accessibilityLabel={`Open trail issue ${issues.name}`}>
             <View style={styles.cardContainer}>
                 {/* Left: Image */}
                 <View style={styles.imageContainer}>
@@ -47,19 +54,16 @@ export function TrailDocIssuesCard(issues: Readonly<TrailIssue & { onPress?: () 
                     </Text>
                     <Text style={styles.dateText}>{formattedDate}</Text>
                 </View>
-                {/* Right: Green Arrow Button */}
-                <TouchableOpacity
-                    style={styles.arrowButton}
-                    activeOpacity={0.7}
-                    onPress={issues.onPress}>
+                {/* Right: Green Arrow — decorative, the card itself handles the tap */}
+                <View style={styles.arrowButton}>
                     <Feather
                         name="chevron-right"
                         size={18}
                         color="#ffffff"
                     />
-                </TouchableOpacity>
+                </View>
             </View>
-        </View>
+        </TouchableOpacity>
 
         </>
     );

--- a/frontend/components/ui/trail-event-card.tsx
+++ b/frontend/components/ui/trail-event-card.tsx
@@ -57,7 +57,7 @@ export default function TrailEventCard({
                         </Pressable>
 
                         {/* Title */}
-                        <Text style={styles.heading}>Today's Event</Text>
+                        <Text style={styles.heading}>Today&apos;s Event</Text>
                         <View style={styles.divider} />
 
                         {/* Event details */}

--- a/frontend/components/ui/trail-event-header.tsx
+++ b/frontend/components/ui/trail-event-header.tsx
@@ -15,7 +15,6 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import EndEventModal from "./end-event-modal";
 
-const API_KEY = process.env.EXPO_PUBLIC_TRELLO_API_KEY ?? "";
 
 interface TrailEventHeaderProps {
     event: Event;

--- a/frontend/components/ui/trello-login.tsx
+++ b/frontend/components/ui/trello-login.tsx
@@ -1,9 +1,7 @@
 import { useGoogleAuth } from "@/auth";
-import { subscribeToAuthState } from "@/auth/google-auth";
 import { Palette } from "@/constants/theme";
 import { Stack } from "expo-router";
-import { User } from "firebase/auth";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {
     ActivityIndicator,
     Dimensions,

--- a/frontend/config/firebase.ts
+++ b/frontend/config/firebase.ts
@@ -1,17 +1,38 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { getApp, getApps, initializeApp } from "firebase/app";
 import { Auth, getAuth, initializeAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
 
-// @ts-ignore
+// firebase v11 does not re-export getReactNativePersistence from its typed
+// entrypoint, so this is the only way to reach it.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { getReactNativePersistence } = require("firebase/auth");
 
-const firebaseConfig = {
+const REQUIRED_CONFIG = {
     apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
     authDomain: process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN,
     projectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID,
     storageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET,
     messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
     appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
+};
+
+const missing = Object.entries(REQUIRED_CONFIG)
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+// Without this the app boots and then fails deep inside an unrelated screen
+// with an opaque Firebase error — most often on an EAS build where the
+// EXPO_PUBLIC_* vars were never added to the build environment.
+if (missing.length > 0) {
+    throw new Error(
+        `Firebase config is incomplete — missing ${missing.join(", ")}. ` +
+            `Check that every EXPO_PUBLIC_FIREBASE_* variable is set (see .env.example).`,
+    );
+}
+
+const firebaseConfig = {
+    ...REQUIRED_CONFIG,
     measurementId: process.env.EXPO_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
@@ -23,8 +44,21 @@ try {
     auth = initializeAuth(firebaseApp, {
         persistence: getReactNativePersistence(AsyncStorage),
     });
-} catch {
+} catch (error) {
+    // initializeAuth throws if it has already run for this app (Fast Refresh,
+    // duplicate import). Anything else means persistence is genuinely
+    // unavailable and sessions will not survive a restart, so say so.
+    const alreadyInitialized =
+        error instanceof Error && error.message.includes("already-initialized");
+    if (!alreadyInitialized) {
+        console.error(
+            "Firebase auth persistence unavailable; sign-in will not survive an app restart:",
+            error,
+        );
+    }
     auth = getAuth(firebaseApp);
 }
+
+export const db = getFirestore(firebaseApp);
 
 export { auth };

--- a/frontend/hooks/use-google-auth.ts
+++ b/frontend/hooks/use-google-auth.ts
@@ -6,12 +6,12 @@ import { useCallback, useEffect, useState } from "react";
 import { Platform } from "react-native";
 import {
     AuthError,
-    getValidAccessToken,
     googleAuthConfig,
     handleGoogleAuthResponse,
     signOut,
     subscribeToAuthState,
 } from "../auth/google-auth";
+import { getErrorMessage } from "@/utils/errors";
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -61,11 +61,11 @@ export function useGoogleAuth() {
             try {
                 await handleGoogleAuthResponse(response);
             } catch (err) {
-                if (err instanceof AuthError) {
-                    setError(err);
-                } else {
-                    setError(new AuthError("UNKNOWN", (err as Error).message));
-                }
+                setError(
+                    err instanceof AuthError
+                        ? err
+                        : new AuthError("UNKNOWN", getErrorMessage(err)),
+                );
             } finally {
                 setLoading(false);
             }
@@ -82,7 +82,7 @@ export function useGoogleAuth() {
         try {
             await promptAsync();
         } catch (err) {
-            setError(new AuthError("UNKNOWN", (err as Error).message));
+            setError(new AuthError("UNKNOWN", getErrorMessage(err)));
         } finally {
             setLoading(false);
         }
@@ -96,36 +96,10 @@ export function useGoogleAuth() {
             setUser(null);
             setError(null);
         } catch (err) {
-            if (err instanceof AuthError) {
-                setError(err);
-            } else {
-                const code = (err as any)?.code as string | undefined;
-                if (code === "auth/network-request-failed") {
-                    setError(
-                        new AuthError(
-                            "NETWORK",
-                            "No internet connection. Please try again.",
-                        ),
-                    );
-                } else if (code === "auth/user-token-expired") {
-                    setError(
-                        new AuthError(
-                            "SESSION_EXPIRED",
-                            "Your session has expired. Please sign in again.",
-                        ),
-                    );
-                } else {
-                    setError(new AuthError("UNKNOWN", (err as Error).message));
-                }
-            }
+            setError(toAuthError(err));
         } finally {
             setLoading(false);
         }
-    }, []);
-
-    // getter for access token
-    const getAccessToken = useCallback(async () => {
-        return getValidAccessToken();
     }, []);
 
     return {
@@ -135,7 +109,28 @@ export function useGoogleAuth() {
         error,
         promptSignIn,
         handleSignOut,
-        getAccessToken,
         isReady: !!request,
     };
+}
+
+function toAuthError(error: unknown): AuthError {
+    if (error instanceof AuthError) return error;
+
+    const code =
+        typeof error === "object" && error !== null && "code" in error
+            ? String((error as { code: unknown }).code)
+            : "";
+    if (code === "auth/network-request-failed") {
+        return new AuthError(
+            "NETWORK",
+            "No internet connection. Please try again.",
+        );
+    }
+    if (code === "auth/user-token-expired") {
+        return new AuthError(
+            "SESSION_EXPIRED",
+            "Your session has expired. Please sign in again.",
+        );
+    }
+    return new AuthError("UNKNOWN", getErrorMessage(error));
 }

--- a/frontend/hooks/use-is-admin.ts
+++ b/frontend/hooks/use-is-admin.ts
@@ -2,20 +2,46 @@ import { auth } from "@/config/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 import { useEffect, useState } from "react";
 
-const ADMIN_EMAIL = process.env.EXPO_PUBLIC_ADMIN_EMAIL ?? "";
-
+// Reads the `admin` custom claim rather than comparing against a bundled email.
+// The old EXPO_PUBLIC_ADMIN_EMAIL compare shipped in the JS bundle, was
+// trivially spoofable, and could not be referenced from firestore.rules — so
+// nothing enforced it server-side. Grant the claim with:
+//   cd backend && npm run set-admin -- someone@example.com
 export function useIsAdmin(): boolean | null {
     const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
 
     useEffect(() => {
+        let cancelled = false;
         const unsubscribe = onAuthStateChanged(auth, (user) => {
-            setIsAdmin(
-                !!user &&
-                    !!ADMIN_EMAIL &&
-                    user.email?.toLowerCase() === ADMIN_EMAIL.toLowerCase(),
-            );
+            if (!user) {
+                if (!cancelled) setIsAdmin(false);
+                return;
+            }
+            // The cached ID token can be up to an hour old, so a freshly
+            // granted claim would otherwise stay invisible with no explanation.
+            // Check the cached token first (free), and only force a refresh
+            // when it says non-admin — so existing admins pay nothing and a
+            // newly granted one sees it immediately.
+            user.getIdTokenResult()
+                .then((cached) =>
+                    cached.claims.admin === true
+                        ? true
+                        : user
+                              .getIdTokenResult(true)
+                              .then((fresh) => fresh.claims.admin === true),
+                )
+                .then((admin) => {
+                    if (!cancelled) setIsAdmin(admin);
+                })
+                .catch((error: unknown) => {
+                    console.error("Failed to read admin claim:", error);
+                    if (!cancelled) setIsAdmin(false);
+                });
         });
-        return () => unsubscribe();
+        return () => {
+            cancelled = true;
+            unsubscribe();
+        };
     }, []);
 
     return isAdmin;

--- a/frontend/services/require-user.ts
+++ b/frontend/services/require-user.ts
@@ -1,0 +1,13 @@
+import { auth } from "@/config/firebase";
+import type { User } from "firebase/auth";
+
+// Converts a would-be Firestore permission-denied into a readable message and
+// saves a round-trip. This is a UX guard, not a security boundary — the real
+// enforcement lives in firestore.rules.
+export function requireUser(action: string): User {
+    const currentUser = auth.currentUser;
+    if (!currentUser) {
+        throw new Error(`You must be signed in to ${action}.`);
+    }
+    return currentUser;
+}

--- a/frontend/services/trello-funcs.ts
+++ b/frontend/services/trello-funcs.ts
@@ -1,6 +1,11 @@
 import { parseAndValidateDate } from "@/utils/date";
-import type { AxiosInstance, InternalAxiosRequestConfig } from "axios";
-import axios from "axios";
+import { getErrorMessage } from "@/utils/errors";
+import {
+    create as createAxios,
+    isAxiosError,
+    type AxiosInstance,
+    type InternalAxiosRequestConfig,
+} from "axios";
 import { getTrelloToken } from "../auth/trello-token-storage";
 import { TrelloAuthError } from "./trello-auth-error";
 import type {
@@ -10,17 +15,6 @@ import type {
     List,
     TrelloAttachment,
 } from "./trello-types";
-
-// helper for error message from unknown error type
-function getErrorMessage(error: unknown): string {
-    if (error instanceof Error) {
-        return error.message;
-    }
-    if (typeof error === "string") {
-        return error;
-    }
-    return String(error) || "Unknown error";
-}
 
 function isTrelloHost(url: string): boolean {
     try {
@@ -50,7 +44,7 @@ export class TrelloClient {
 
     constructor(key: string) {
         this.key = key;
-        this.client = axios.create({
+        this.client = createAxios({
             baseURL: "https://api.trello.com/1",
         });
 
@@ -80,7 +74,7 @@ export class TrelloClient {
         this.client.interceptors.response.use(
             (response) => response,
             (error: unknown) => {
-                if (axios.isAxiosError(error)) {
+                if (isAxiosError(error)) {
                     if (error.response?.status) {
                         handleHttpError(error.response.status);
                         // non-auth status, re-throw original
@@ -132,7 +126,6 @@ export class TrelloClient {
                 idList: listID,
                 name: name,
                 desc: description || "",
-                fields: "id,name,desc,idList,idBoard,shortUrl",
             });
             return response.data;
         } catch (error) {
@@ -402,7 +395,37 @@ export class TrelloClient {
             );
             return card;
         } catch (error) {
-            console.error("unable to get card:", error);
+            if (error instanceof TrelloAuthError) throw error;
+            console.error(
+                `unable to get card ${cardID}:`,
+                getErrorMessage(error),
+            );
+            throw error;
+        }
+    }
+
+    async addAttachment(cardID: string, url: string): Promise<void> {
+        try {
+            await this.client.post(`/cards/${cardID}/attachments`, { url });
+        } catch (error) {
+            if (error instanceof TrelloAuthError) throw error;
+            console.error(
+                `unable to attach to card ${cardID}:`,
+                getErrorMessage(error),
+            );
+            throw error;
+        }
+    }
+
+    async archiveCard(cardID: string): Promise<void> {
+        try {
+            await this.client.put(`/cards/${cardID}`, { closed: true });
+        } catch (error) {
+            if (error instanceof TrelloAuthError) throw error;
+            console.error(
+                `unable to archive card ${cardID}:`,
+                getErrorMessage(error),
+            );
             throw error;
         }
     }
@@ -421,7 +444,11 @@ export class TrelloClient {
             }
             return eventCard;
         } catch (error) {
-            console.error("unable to get event card:", error);
+            if (error instanceof TrelloAuthError) throw error;
+            console.error(
+                `unable to get event card ${cardID}:`,
+                getErrorMessage(error),
+            );
             throw error;
         }
     }
@@ -464,7 +491,7 @@ export class TrelloClient {
         } catch (error) {
             if (error instanceof TrelloAuthError) throw error;
 
-            console.error("Error loading image:", error);
+            console.error("Error loading image:", getErrorMessage(error));
             return null;
         }
     }

--- a/frontend/types/trail-types.tsx
+++ b/frontend/types/trail-types.tsx
@@ -7,13 +7,16 @@ export type TrailIssue = {
     afterImageUri?: string | null;
 };
 
-export type TrailDocumentScreenProps = {
-    eventCardID: string;
+export type TrailIssueItem = {
+    id: string;
+    name: string;
+    description: string;
+    imageUrl: string | null;
 };
 
-export interface TrailDocumentIssueItem {
+export type TrailDocumentIssueItem = {
     id: string;
     name: string;
     imageUrl: string | null;
     creationDate: Date;
-}
+};

--- a/frontend/utils/errors.ts
+++ b/frontend/utils/errors.ts
@@ -1,0 +1,9 @@
+export function getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    if (typeof error === "string") {
+        return error;
+    }
+    return String(error) || "Unknown error";
+}


### PR DESCRIPTION
Three leaves that everything downstream builds on.

utils/errors.ts holds getErrorMessage, which was duplicated privately inside
trello-funcs.ts and hand-rolled as (e as Error).message at a dozen call sites.

services/require-user.ts converts a would-be Firestore permission-denied into a
readable message and saves a round-trip. It is explicitly UX, not security: the
real enforcement is firestore.rules.

config/firebase.ts gains an exported db, replacing 13 ad-hoc getFirestore()
calls across the codebase, and validates the six required EXPO_PUBLIC_FIREBASE_*
vars at startup. Without that check the app boots and then fails deep inside an
unrelated screen with an opaque error, most often on an EAS build where the vars
were never added to the build environment. It also stops swallowing every
initializeAuth failure with a bare catch {}, which silently downgraded auth to
non-persistent.

.env.example drops EXPO_PUBLIC_TRELLO_API_TOKEN, a real write-capable token with
zero code references and one accidental reference away from shipping in a public
binary, plus the Google client secret the old template told contributors to put
in a mobile env file.

Purely additive: main's existing getFirestore() call sites keep compiling.



---

### The stack

Merge bottom-up. Each PR is reviewable alone and introduces no new typecheck errors.

| PR | Change | Files |
|----|--------|-------|
| #90 | backend: Firebase ID token auth, CORS, testable refactor | 32 |
| #91 | firestore: rules, indexes, emulator suite | 9 |
| #92 | docs + CI (backend & firestore jobs) | 5 |
| #93 | delete the Expo starter template | 15 |
| #94 | delete dead scripts + Sheets integration | 6 |
| #95 | fix the typecheck gate, add jest, commit lockfile | 7 |
| #96 | shared error/auth helpers, single Firestore handle | 4 |
| #97 | stop leaking Trello credentials; admin custom claim | 9 |
| #98 | cache Trello board/list ids; publish ordering | 7 |
| #99 | Google Photos via the backend proxy | 5 |
| #100 | event ownership, rollback-safe setup, hours of service | 9 |
| #101 | CI: add the frontend job | 1 |
| #102 | persist and upload trail photos | 8 |
| #103 | one auth subscription; delete dead token layer | 6 |
| #104 | link EAS environments to build profiles | 2 |

`origin/main` has **67 typecheck errors today**. They fall to 8 at #93, 6 at #100, and 0 at #102 — the count never rises.

CI runs from #92 onward (backend + firestore), and covers all three packages from #101.
