### PR TITLE
frontend: stop leaking Trello credentials into logs; admin via custom claim

### DIFF
--- a/frontend/app/auth.tsx
+++ b/frontend/app/auth.tsx
@@ -21,7 +21,7 @@ export default function AuthScreen() {
         if (user) {
             router.replace("/home-screen");
         }
-    }, [user]);
+    }, [user, router]);
 
     const errorMessage = error ? getErrorMessage(error.code) : undefined;
 

--- a/frontend/components/ui/trail-doc-issues-card.tsx
+++ b/frontend/components/ui/trail-doc-issues-card.tsx
@@ -25,7 +25,14 @@ export function TrailDocIssuesCard(issues: Readonly<TrailIssue & { onPress?: () 
 
     return (
         <>
-        <View style={styles.outer}>
+        {/* The whole card is the tap target. Only the 32px chevron used to be
+            pressable, and this card is the sole way into an issue. */}
+        <TouchableOpacity
+            style={styles.outer}
+            activeOpacity={0.7}
+            onPress={issues.onPress}
+            accessibilityRole="button"
+            accessibilityLabel={`Open trail issue ${issues.name}`}>
             <View style={styles.cardContainer}>
                 {/* Left: Image */}
                 <View style={styles.imageContainer}>
@@ -47,19 +54,16 @@ export function TrailDocIssuesCard(issues: Readonly<TrailIssue & { onPress?: () 
                     </Text>
                     <Text style={styles.dateText}>{formattedDate}</Text>
                 </View>
-                {/* Right: Green Arrow Button */}
-                <TouchableOpacity
-                    style={styles.arrowButton}
-                    activeOpacity={0.7}
-                    onPress={issues.onPress}>
+                {/* Right: Green Arrow — decorative, the card itself handles the tap */}
+                <View style={styles.arrowButton}>
                     <Feather
                         name="chevron-right"
                         size={18}
                         color="#ffffff"
                     />
-                </TouchableOpacity>
+                </View>
             </View>
-        </View>
+        </TouchableOpacity>
 
         </>
     );

--- a/frontend/components/ui/trail-event-card.tsx
+++ b/frontend/components/ui/trail-event-card.tsx
@@ -57,7 +57,7 @@ export default function TrailEventCard({
                         </Pressable>
 
                         {/* Title */}
-                        <Text style={styles.heading}>Today's Event</Text>
+                        <Text style={styles.heading}>Today&apos;s Event</Text>
                         <View style={styles.divider} />
 
                         {/* Event details */}

--- a/frontend/components/ui/trail-event-header.tsx
+++ b/frontend/components/ui/trail-event-header.tsx
@@ -15,7 +15,6 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import EndEventModal from "./end-event-modal";
 
-const API_KEY = process.env.EXPO_PUBLIC_TRELLO_API_KEY ?? "";
 
 interface TrailEventHeaderProps {
     event: Event;

--- a/frontend/components/ui/trello-login.tsx
+++ b/frontend/components/ui/trello-login.tsx
@@ -1,9 +1,7 @@
 import { useGoogleAuth } from "@/auth";
-import { subscribeToAuthState } from "@/auth/google-auth";
 import { Palette } from "@/constants/theme";
 import { Stack } from "expo-router";
-import { User } from "firebase/auth";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {
     ActivityIndicator,
     Dimensions,

--- a/frontend/hooks/use-google-auth.ts
+++ b/frontend/hooks/use-google-auth.ts
@@ -6,12 +6,12 @@ import { useCallback, useEffect, useState } from "react";
 import { Platform } from "react-native";
 import {
     AuthError,
-    getValidAccessToken,
     googleAuthConfig,
     handleGoogleAuthResponse,
     signOut,
     subscribeToAuthState,
 } from "../auth/google-auth";
+import { getErrorMessage } from "@/utils/errors";
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -61,11 +61,11 @@ export function useGoogleAuth() {
             try {
                 await handleGoogleAuthResponse(response);
             } catch (err) {
-                if (err instanceof AuthError) {
-                    setError(err);
-                } else {
-                    setError(new AuthError("UNKNOWN", (err as Error).message));
-                }
+                setError(
+                    err instanceof AuthError
+                        ? err
+                        : new AuthError("UNKNOWN", getErrorMessage(err)),
+                );
             } finally {
                 setLoading(false);
             }
@@ -82,7 +82,7 @@ export function useGoogleAuth() {
         try {
             await promptAsync();
         } catch (err) {
-            setError(new AuthError("UNKNOWN", (err as Error).message));
+            setError(new AuthError("UNKNOWN", getErrorMessage(err)));
         } finally {
             setLoading(false);
         }
@@ -96,36 +96,10 @@ export function useGoogleAuth() {
             setUser(null);
             setError(null);
         } catch (err) {
-            if (err instanceof AuthError) {
-                setError(err);
-            } else {
-                const code = (err as any)?.code as string | undefined;
-                if (code === "auth/network-request-failed") {
-                    setError(
-                        new AuthError(
-                            "NETWORK",
-                            "No internet connection. Please try again.",
-                        ),
-                    );
-                } else if (code === "auth/user-token-expired") {
-                    setError(
-                        new AuthError(
-                            "SESSION_EXPIRED",
-                            "Your session has expired. Please sign in again.",
-                        ),
-                    );
-                } else {
-                    setError(new AuthError("UNKNOWN", (err as Error).message));
-                }
-            }
+            setError(toAuthError(err));
         } finally {
             setLoading(false);
         }
-    }, []);
-
-    // getter for access token
-    const getAccessToken = useCallback(async () => {
-        return getValidAccessToken();
     }, []);
 
     return {
@@ -135,7 +109,28 @@ export function useGoogleAuth() {
         error,
         promptSignIn,
         handleSignOut,
-        getAccessToken,
         isReady: !!request,
     };
+}
+
+function toAuthError(error: unknown): AuthError {
+    if (error instanceof AuthError) return error;
+
+    const code =
+        typeof error === "object" && error !== null && "code" in error
+            ? String((error as { code: unknown }).code)
+            : "";
+    if (code === "auth/network-request-failed") {
+        return new AuthError(
+            "NETWORK",
+            "No internet connection. Please try again.",
+        );
+    }
+    if (code === "auth/user-token-expired") {
+        return new AuthError(
+            "SESSION_EXPIRED",
+            "Your session has expired. Please sign in again.",
+        );
+    }
+    return new AuthError("UNKNOWN", getErrorMessage(error));
 }

--- a/frontend/hooks/use-is-admin.ts
+++ b/frontend/hooks/use-is-admin.ts
@@ -2,20 +2,46 @@ import { auth } from "@/config/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 import { useEffect, useState } from "react";
 
-const ADMIN_EMAIL = process.env.EXPO_PUBLIC_ADMIN_EMAIL ?? "";
-
+// Reads the `admin` custom claim rather than comparing against a bundled email.
+// The old EXPO_PUBLIC_ADMIN_EMAIL compare shipped in the JS bundle, was
+// trivially spoofable, and could not be referenced from firestore.rules — so
+// nothing enforced it server-side. Grant the claim with:
+//   cd backend && npm run set-admin -- someone@example.com
 export function useIsAdmin(): boolean | null {
     const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
 
     useEffect(() => {
+        let cancelled = false;
         const unsubscribe = onAuthStateChanged(auth, (user) => {
-            setIsAdmin(
-                !!user &&
-                    !!ADMIN_EMAIL &&
-                    user.email?.toLowerCase() === ADMIN_EMAIL.toLowerCase(),
-            );
+            if (!user) {
+                if (!cancelled) setIsAdmin(false);
+                return;
+            }
+            // The cached ID token can be up to an hour old, so a freshly
+            // granted claim would otherwise stay invisible with no explanation.
+            // Check the cached token first (free), and only force a refresh
+            // when it says non-admin — so existing admins pay nothing and a
+            // newly granted one sees it immediately.
+            user.getIdTokenResult()
+                .then((cached) =>
+                    cached.claims.admin === true
+                        ? true
+                        : user
+                              .getIdTokenResult(true)
+                              .then((fresh) => fresh.claims.admin === true),
+                )
+                .then((admin) => {
+                    if (!cancelled) setIsAdmin(admin);
+                })
+                .catch((error: unknown) => {
+                    console.error("Failed to read admin claim:", error);
+                    if (!cancelled) setIsAdmin(false);
+                });
         });
-        return () => unsubscribe();
+        return () => {
+            cancelled = true;
+            unsubscribe();
+        };
     }, []);
 
     return isAdmin;

--- a/frontend/services/trello-funcs.ts
+++ b/frontend/services/trello-funcs.ts
@@ -1,6 +1,11 @@
 import { parseAndValidateDate } from "@/utils/date";
-import type { AxiosInstance, InternalAxiosRequestConfig } from "axios";
-import axios from "axios";
+import { getErrorMessage } from "@/utils/errors";
+import {
+    create as createAxios,
+    isAxiosError,
+    type AxiosInstance,
+    type InternalAxiosRequestConfig,
+} from "axios";
 import { getTrelloToken } from "../auth/trello-token-storage";
 import { TrelloAuthError } from "./trello-auth-error";
 import type {
@@ -10,17 +15,6 @@ import type {
     List,
     TrelloAttachment,
 } from "./trello-types";
-
-// helper for error message from unknown error type
-function getErrorMessage(error: unknown): string {
-    if (error instanceof Error) {
-        return error.message;
-    }
-    if (typeof error === "string") {
-        return error;
-    }
-    return String(error) || "Unknown error";
-}
 
 function isTrelloHost(url: string): boolean {
     try {
@@ -50,7 +44,7 @@ export class TrelloClient {
 
     constructor(key: string) {
         this.key = key;
-        this.client = axios.create({
+        this.client = createAxios({
             baseURL: "https://api.trello.com/1",
         });
 
@@ -80,7 +74,7 @@ export class TrelloClient {
         this.client.interceptors.response.use(
             (response) => response,
             (error: unknown) => {
-                if (axios.isAxiosError(error)) {
+                if (isAxiosError(error)) {
                     if (error.response?.status) {
                         handleHttpError(error.response.status);
                         // non-auth status, re-throw original
@@ -132,7 +126,6 @@ export class TrelloClient {
                 idList: listID,
                 name: name,
                 desc: description || "",
-                fields: "id,name,desc,idList,idBoard,shortUrl",
             });
             return response.data;
         } catch (error) {
@@ -402,7 +395,37 @@ export class TrelloClient {
             );
             return card;
         } catch (error) {
-            console.error("unable to get card:", error);
+            if (error instanceof TrelloAuthError) throw error;
+            console.error(
+                `unable to get card ${cardID}:`,
+                getErrorMessage(error),
+            );
+            throw error;
+        }
+    }
+
+    async addAttachment(cardID: string, url: string): Promise<void> {
+        try {
+            await this.client.post(`/cards/${cardID}/attachments`, { url });
+        } catch (error) {
+            if (error instanceof TrelloAuthError) throw error;
+            console.error(
+                `unable to attach to card ${cardID}:`,
+                getErrorMessage(error),
+            );
+            throw error;
+        }
+    }
+
+    async archiveCard(cardID: string): Promise<void> {
+        try {
+            await this.client.put(`/cards/${cardID}`, { closed: true });
+        } catch (error) {
+            if (error instanceof TrelloAuthError) throw error;
+            console.error(
+                `unable to archive card ${cardID}:`,
+                getErrorMessage(error),
+            );
             throw error;
         }
     }
@@ -421,7 +444,11 @@ export class TrelloClient {
             }
             return eventCard;
         } catch (error) {
-            console.error("unable to get event card:", error);
+            if (error instanceof TrelloAuthError) throw error;
+            console.error(
+                `unable to get event card ${cardID}:`,
+                getErrorMessage(error),
+            );
             throw error;
         }
     }
@@ -464,7 +491,7 @@ export class TrelloClient {
         } catch (error) {
             if (error instanceof TrelloAuthError) throw error;
 
-            console.error("Error loading image:", error);
+            console.error("Error loading image:", getErrorMessage(error));
             return null;
         }
     }

--- a/frontend/types/trail-types.tsx
+++ b/frontend/types/trail-types.tsx
@@ -7,13 +7,16 @@ export type TrailIssue = {
     afterImageUri?: string | null;
 };
 
-export type TrailDocumentScreenProps = {
-    eventCardID: string;
+export type TrailIssueItem = {
+    id: string;
+    name: string;
+    description: string;
+    imageUrl: string | null;
 };
 
-export interface TrailDocumentIssueItem {
+export type TrailDocumentIssueItem = {
     id: string;
     name: string;
     imageUrl: string | null;
     creationDate: Date;
-}
+};


### PR DESCRIPTION
trello-funcs.ts getCardByID, getEventCardByID and loadTrelloImage logged the raw
Axios error, whose config.params carries the Trello API key and the user's OAuth
token, injected by the request interceptor. Those went straight into device logs
and any crash reporting. Every other method in the file already used
getErrorMessage; these now match.

use-is-admin.ts compared user.email against EXPO_PUBLIC_ADMIN_EMAIL. That value
is inlined into the shipped JS bundle, is trivially spoofable, and cannot be
referenced from firestore.rules, so nothing enforced it server-side. It now
reads a Firebase custom claim, which the rules do check. It reads the cached ID
token first and only forces a refresh when that says non-admin, so a freshly
granted admin sees it immediately instead of waiting up to an hour.

Also adds TrelloClient.archiveCard and addAttachment, needed by later PRs; moves
TrailIssueItem into types/trail-types so it survives deleting trail-issues-card;
makes the whole trail issue card tappable rather than just its 32px chevron,
which is the only way into an issue; and clears one eslint error and four
unused-import warnings.



---

### The stack

Merge bottom-up. Each PR is reviewable alone and introduces no new typecheck errors.

| PR | Change | Files |
|----|--------|-------|
| #90 | backend: Firebase ID token auth, CORS, testable refactor | 32 |
| #91 | firestore: rules, indexes, emulator suite | 9 |
| #92 | docs + CI (backend & firestore jobs) | 5 |
| #93 | delete the Expo starter template | 15 |
| #94 | delete dead scripts + Sheets integration | 6 |
| #95 | fix the typecheck gate, add jest, commit lockfile | 7 |
| #96 | shared error/auth helpers, single Firestore handle | 4 |
| #97 | stop leaking Trello credentials; admin custom claim | 9 |
| #98 | cache Trello board/list ids; publish ordering | 7 |
| #99 | Google Photos via the backend proxy | 5 |
| #100 | event ownership, rollback-safe setup, hours of service | 9 |
| #101 | CI: add the frontend job | 1 |
| #102 | persist and upload trail photos | 8 |
| #103 | one auth subscription; delete dead token layer | 6 |
| #104 | link EAS environments to build profiles | 2 |

`origin/main` has **67 typecheck errors today**. They fall to 8 at #93, 6 at #100, and 0 at #102 — the count never rises.

CI runs from #92 onward (backend + firestore), and covers all three packages from #101.
