### PR TITLE
frontend: reach Google Photos through the backend proxy

### DIFF
--- a/frontend/api/__tests__/backend-client.test.ts
+++ b/frontend/api/__tests__/backend-client.test.ts
@@ -1,0 +1,183 @@
+import { auth } from "@/config/firebase";
+import {
+    BackendError,
+    createAlbum,
+    listAlbumsPage,
+    listAllAlbums,
+    uploadPhotos,
+} from "../backend-client";
+
+const mutableAuth = auth as {
+    currentUser: { getIdToken: jest.Mock } | null;
+};
+
+const getIdToken = jest.fn();
+const fetchMock = jest.fn();
+
+function json(body: unknown, status = 200): Response {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+    } as unknown as Response;
+}
+
+beforeEach(() => {
+    process.env.EXPO_PUBLIC_BACKEND_URL = "https://api.example";
+    getIdToken.mockResolvedValue("id-token");
+    mutableAuth.currentUser = { getIdToken };
+    global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+    mutableAuth.currentUser = null;
+});
+
+describe("configuration and sign-in guards", () => {
+    it("fails with an actionable message when the backend URL is unset", async () => {
+        process.env.EXPO_PUBLIC_BACKEND_URL = "";
+        await expect(createAlbum("Cleanup")).rejects.toMatchObject({
+            code: "NOT_CONFIGURED",
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("fails when nobody is signed in", async () => {
+        mutableAuth.currentUser = null;
+        await expect(createAlbum("Cleanup")).rejects.toMatchObject({
+            code: "NOT_SIGNED_IN",
+        });
+    });
+
+    it("trims a trailing slash off the backend URL", async () => {
+        process.env.EXPO_PUBLIC_BACKEND_URL = "https://api.example/";
+        fetchMock.mockResolvedValue(json({ id: "a1", title: "Cleanup" }, 201));
+        await createAlbum("Cleanup");
+        expect(fetchMock.mock.calls[0][0]).toBe("https://api.example/api/albums");
+    });
+});
+
+describe("authorization", () => {
+    it("attaches the Firebase ID token", async () => {
+        fetchMock.mockResolvedValue(json({ id: "a1", title: "Cleanup" }, 201));
+        await createAlbum("Cleanup");
+
+        const init = fetchMock.mock.calls[0][1] as RequestInit;
+        expect(
+            (init.headers as Record<string, string>).Authorization,
+        ).toBe("Bearer id-token");
+    });
+
+    it("retries once with a force-refreshed token on 401", async () => {
+        getIdToken
+            .mockResolvedValueOnce("stale-token")
+            .mockResolvedValueOnce("fresh-token");
+        fetchMock
+            .mockResolvedValueOnce(json({ error: "expired" }, 401))
+            .mockResolvedValueOnce(json({ id: "a1", title: "Cleanup" }, 201));
+
+        await expect(createAlbum("Cleanup")).resolves.toEqual({
+            id: "a1",
+            title: "Cleanup",
+        });
+
+        expect(getIdToken).toHaveBeenNthCalledWith(1, false);
+        expect(getIdToken).toHaveBeenNthCalledWith(2, true);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("gives up after exactly one retry", async () => {
+        fetchMock.mockResolvedValue(json({ error: "nope" }, 401));
+        await expect(createAlbum("Cleanup")).rejects.toMatchObject({
+            code: "UNAUTHORIZED",
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe("error mapping", () => {
+    it.each([
+        [403, "FORBIDDEN"],
+        [404, "NOT_FOUND"],
+        [502, "UPSTREAM"],
+        [500, "UNKNOWN"],
+    ])("maps HTTP %i to %s", async (status, code) => {
+        fetchMock.mockResolvedValue(json({ error: "bad" }, status));
+        await expect(createAlbum("Cleanup")).rejects.toMatchObject({ code });
+    });
+
+    it("reports a network failure rather than leaking the raw error", async () => {
+        fetchMock.mockRejectedValue(new TypeError("Network request failed"));
+        const error = await createAlbum("Cleanup").catch((e: unknown) => e);
+        expect(error).toBeInstanceOf(BackendError);
+        expect((error as BackendError).code).toBe("NETWORK");
+    });
+});
+
+describe("pagination", () => {
+    it("defaults albums to an empty array when the payload omits it", async () => {
+        fetchMock.mockResolvedValue(json({}));
+        await expect(listAlbumsPage()).resolves.toEqual({
+            albums: [],
+            nextPageToken: undefined,
+        });
+    });
+
+    it("follows nextPageToken until exhausted", async () => {
+        fetchMock
+            .mockResolvedValueOnce(
+                json({ albums: [{ id: "a1", title: "One" }], nextPageToken: "t2" }),
+            )
+            .mockResolvedValueOnce(json({ albums: [{ id: "a2", title: "Two" }] }));
+
+        await expect(listAllAlbums()).resolves.toHaveLength(2);
+        expect(fetchMock.mock.calls[1][0]).toContain("pageToken=t2");
+    });
+});
+
+describe("uploadPhotos", () => {
+    it("short-circuits with no photos", async () => {
+        await expect(uploadPhotos("album-1", [])).resolves.toEqual({
+            created: 0,
+            failed: [],
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("treats a 207 partial success as a result, not an error", async () => {
+        fetchMock.mockResolvedValue(
+            json(
+                {
+                    newMediaItemResults: [{}],
+                    failed: [{ fileName: "after.jpg", error: "boom" }],
+                },
+                207,
+            ),
+        );
+
+        await expect(
+            uploadPhotos("album-1", [
+                { uri: "file:///a.jpg", fileName: "a.jpg", mimeType: "image/jpeg" },
+            ]),
+        ).resolves.toEqual({
+            created: 1,
+            failed: [{ fileName: "after.jpg", error: "boom" }],
+        });
+    });
+
+    it("rebuilds the body on the 401 retry so it is not a consumed stream", async () => {
+        fetchMock
+            .mockResolvedValueOnce(json({ error: "expired" }, 401))
+            .mockResolvedValueOnce(json({ newMediaItemResults: [{}] }, 201));
+
+        await uploadPhotos("album-1", [
+            { uri: "file:///a.jpg", fileName: "a.jpg", mimeType: "image/jpeg" },
+        ]);
+
+        const firstBody = (fetchMock.mock.calls[0][1] as RequestInit).body;
+        const secondBody = (fetchMock.mock.calls[1][1] as RequestInit).body;
+        expect(firstBody).toBeDefined();
+        expect(secondBody).toBeDefined();
+        expect(firstBody).not.toBe(secondBody);
+    });
+});

--- a/frontend/api/backend-client.ts
+++ b/frontend/api/backend-client.ts
@@ -1,0 +1,269 @@
+import { auth } from "@/config/firebase";
+
+// Photos live in the MVT-owned Google account, reachable only through our
+// backend proxy. The app holds no Google Photos credentials of its own — it
+// authenticates to the proxy with the signed-in volunteer's Firebase ID token.
+
+export type GooglePhotosAlbum = {
+    id: string;
+    title: string;
+    productUrl?: string;
+    isWriteable?: boolean;
+    // Google returns this as a string; callers coerce where they need a number.
+    mediaItemsCount?: string;
+    coverPhotoBaseUrl?: string;
+    coverPhotoMediaItemId?: string;
+};
+
+export type GooglePhotosAlbumsPage = {
+    albums: GooglePhotosAlbum[];
+    nextPageToken?: string;
+};
+
+export type GooglePhotosMediaItem = {
+    id: string;
+    description?: string;
+    productUrl?: string;
+    baseUrl?: string;
+    mimeType?: string;
+    filename?: string;
+};
+
+export type GooglePhotosMediaPage = {
+    mediaItems: GooglePhotosMediaItem[];
+    nextPageToken?: string;
+};
+
+export type PhotoUpload = {
+    uri: string;
+    fileName: string;
+    mimeType: string;
+    description?: string;
+};
+
+export type UploadFailure = { fileName: string; error: string };
+
+export type UploadResult = {
+    created: number;
+    failed: UploadFailure[];
+};
+
+export type BackendErrorCode =
+    | "NOT_CONFIGURED"
+    | "NOT_SIGNED_IN"
+    | "UNAUTHORIZED"
+    | "FORBIDDEN"
+    | "NOT_FOUND"
+    | "UPSTREAM"
+    | "NETWORK"
+    | "UNKNOWN";
+
+export class BackendError extends Error {
+    readonly code: BackendErrorCode;
+    readonly status: number | null;
+
+    constructor(code: BackendErrorCode, message: string, status: number | null = null) {
+        super(message);
+        this.name = "BackendError";
+        this.code = code;
+        this.status = status;
+    }
+}
+
+function baseUrl(): string {
+    const url = process.env.EXPO_PUBLIC_BACKEND_URL?.trim();
+    if (!url) {
+        throw new BackendError(
+            "NOT_CONFIGURED",
+            "EXPO_PUBLIC_BACKEND_URL is not set. Photo features need the backend " +
+                "proxy — see frontend/.env.example.",
+        );
+    }
+    return url.replace(/\/+$/, "");
+}
+
+async function idToken(forceRefresh: boolean): Promise<string> {
+    const user = auth.currentUser;
+    if (!user) {
+        throw new BackendError(
+            "NOT_SIGNED_IN",
+            "You are signed out. Sign in again to continue.",
+        );
+    }
+    try {
+        return await user.getIdToken(forceRefresh);
+    } catch (error) {
+        throw new BackendError(
+            "NOT_SIGNED_IN",
+            error instanceof Error ? error.message : "Could not get an ID token.",
+        );
+    }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+function readErrorMessage(payload: unknown, fallback: string): string {
+    if (isRecord(payload) && typeof payload.error === "string") return payload.error;
+    return fallback;
+}
+
+async function toError(response: Response): Promise<BackendError> {
+    const payload: unknown = await response.json().catch(() => null);
+    const message = readErrorMessage(
+        payload,
+        `Request failed with status ${response.status}`,
+    );
+    if (response.status === 403) return new BackendError("FORBIDDEN", message, 403);
+    if (response.status === 404) return new BackendError("NOT_FOUND", message, 404);
+    if (response.status === 502) {
+        return new BackendError(
+            "UPSTREAM",
+            "Google Photos is unavailable right now. Please try again.",
+            502,
+        );
+    }
+    if (response.status === 401) {
+        return new BackendError("UNAUTHORIZED", message, 401);
+    }
+    return new BackendError("UNKNOWN", message, response.status);
+}
+
+// Sends the request, and on a 401 retries exactly once with a force-refreshed
+// ID token — the token is only an hour long, so an expiry mid-session is
+// routine rather than exceptional.
+async function send(
+    path: string,
+    init: RequestInit,
+    body?: () => BodyInit,
+): Promise<Response> {
+    // Resolved before the try so a misconfiguration is not reported as a
+    // network failure.
+    const url = `${baseUrl()}${path}`;
+
+    async function attempt(forceRefresh: boolean): Promise<Response> {
+        const token = await idToken(forceRefresh);
+        try {
+            return await fetch(url, {
+                ...init,
+                headers: { ...init.headers, Authorization: `Bearer ${token}` },
+                ...(body ? { body: body() } : {}),
+            });
+        } catch (error) {
+            throw new BackendError(
+                "NETWORK",
+                error instanceof Error
+                    ? `Could not reach the server: ${error.message}`
+                    : "Could not reach the server.",
+            );
+        }
+    }
+
+    const first = await attempt(false);
+    if (first.status !== 401) return first;
+    return attempt(true);
+}
+
+async function getJson<T>(path: string): Promise<T> {
+    const response = await send(path, { method: "GET" });
+    if (!response.ok) throw await toError(response);
+    return (await response.json()) as T;
+}
+
+async function postJson<T>(path: string, payload: unknown): Promise<T> {
+    const response = await send(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+    });
+    if (!response.ok) throw await toError(response);
+    return (await response.json()) as T;
+}
+
+export async function createAlbum(title: string): Promise<GooglePhotosAlbum> {
+    return postJson<GooglePhotosAlbum>("/api/albums", { title });
+}
+
+export async function getAlbum(albumId: string): Promise<GooglePhotosAlbum> {
+    return getJson<GooglePhotosAlbum>(
+        `/api/albums/${encodeURIComponent(albumId)}`,
+    );
+}
+
+export async function listAlbumsPage(
+    pageToken?: string,
+): Promise<GooglePhotosAlbumsPage> {
+    const query = pageToken ? `?pageToken=${encodeURIComponent(pageToken)}` : "";
+    const page = await getJson<Partial<GooglePhotosAlbumsPage>>(
+        `/api/albums${query}`,
+    );
+    return { albums: page.albums ?? [], nextPageToken: page.nextPageToken };
+}
+
+export async function listAllAlbums(): Promise<GooglePhotosAlbum[]> {
+    const albums: GooglePhotosAlbum[] = [];
+    let pageToken: string | undefined;
+    do {
+        const page = await listAlbumsPage(pageToken);
+        albums.push(...page.albums);
+        pageToken = page.nextPageToken;
+    } while (pageToken);
+    return albums;
+}
+
+export async function listAlbumPhotos(
+    albumId: string,
+    pageToken?: string,
+): Promise<GooglePhotosMediaPage> {
+    const query = pageToken ? `?pageToken=${encodeURIComponent(pageToken)}` : "";
+    const page = await getJson<Partial<GooglePhotosMediaPage>>(
+        `/api/albums/${encodeURIComponent(albumId)}/photos${query}`,
+    );
+    return { mediaItems: page.mediaItems ?? [], nextPageToken: page.nextPageToken };
+}
+
+export async function getPhoto(photoId: string): Promise<GooglePhotosMediaItem> {
+    return getJson<GooglePhotosMediaItem>(
+        `/api/photos/${encodeURIComponent(photoId)}`,
+    );
+}
+
+type UploadResponse = {
+    newMediaItemResults?: unknown[];
+    failed?: UploadFailure[];
+};
+
+// React Native's FormData accepts a {uri, name, type} part and streams the file
+// from disk, so a multi-megabyte photo never has to be based64'd into JS memory.
+export async function uploadPhotos(
+    albumId: string,
+    photos: PhotoUpload[],
+): Promise<UploadResult> {
+    if (photos.length === 0) return { created: 0, failed: [] };
+
+    const buildBody = (): BodyInit => {
+        const form = new FormData();
+        form.append("albumId", albumId);
+        for (const photo of photos) {
+            form.append("photos", {
+                uri: photo.uri,
+                name: photo.fileName,
+                type: photo.mimeType,
+            } as unknown as Blob);
+            form.append("descriptions", photo.description ?? "");
+        }
+        return form as unknown as BodyInit;
+    };
+
+    // Body is rebuilt per attempt: a FormData consumed by a failed request
+    // cannot be replayed on the 401 retry.
+    const response = await send("/api/upload", { method: "POST" }, buildBody);
+    if (!response.ok && response.status !== 207) throw await toError(response);
+
+    const payload = (await response.json()) as UploadResponse;
+    return {
+        created: payload.newMediaItemResults?.length ?? 0,
+        failed: payload.failed ?? [],
+    };
+}

--- a/frontend/app/albums.tsx
+++ b/frontend/app/albums.tsx
@@ -1,13 +1,13 @@
-import { listAlbums, type GooglePhotosAlbum } from "@/api/googlePhotosClient";
-import { getValidAccessToken } from "@/auth/google-auth";
+import { listAllAlbums, type GooglePhotosAlbum } from "@/api/backend-client";
 import BottomNav from "@/components/ui/bottom-nav";
 import Header from "@/components/ui/header";
 import { Palette } from "@/constants/theme";
 import { useIsAdmin } from "@/hooks/use-is-admin";
+import { getAlbumCreatedAtMap } from "@/services/album-service";
+import { getErrorMessage } from "@/utils/errors";
 import { MaterialIcons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Stack } from "expo-router";
-import { collection, getDocs, getFirestore } from "firebase/firestore";
 import React, { useCallback, useEffect, useState } from "react";
 import {
     ActivityIndicator,
@@ -26,43 +26,20 @@ type NormalizedAlbum = Omit<GooglePhotosAlbum, "mediaItemsCount"> & {
     mediaItemsCount: number | null;
     appCreatedAt?: number;
 };
-async function getAlbumMeta() {
-    const db = getFirestore();
-    const snapshot = await getDocs(collection(db, "albums"));
-    const map: Record<string, number> = {};
-    snapshot.forEach((doc) => {
-        const data = doc.data();
-        if (data.albumId && data.createdAt) {
-            map[data.albumId] = data.createdAt.toMillis();
-        }
-    });
-    return map;
-}
-
-async function fetchAllAlbums(
-    accessToken: string,
-): Promise<NormalizedAlbum[]> {
-    const all: NormalizedAlbum[] = [];
-    let pageToken: string | undefined;
-    const metaMap = await getAlbumMeta();
-    do {
-        const { albums, nextPageToken } = await listAlbums(
-            accessToken,
-            pageToken,
-        );
-        const normalized = await Promise.all(
-            albums.map(async (a) => {
-                return {
-                    ...a,
-                    mediaItemsCount: a.mediaItemsCount ? Number(a.mediaItemsCount) : null,
-                    appCreatedAt: metaMap[a.id],
-                };
-            })
-        );
-        all.push(...normalized);
-        pageToken = nextPageToken;
-    } while (pageToken);
-    return all;
+// Albums live in the MVT-owned account and are read through the backend proxy,
+// so every volunteer sees the same list. The creation date comes from our own
+// Firestore record — Google Photos does not report one.
+async function fetchAllAlbums(): Promise<NormalizedAlbum[]> {
+    const [albums, createdAtMap] = await Promise.all([
+        listAllAlbums(),
+        getAlbumCreatedAtMap(),
+    ]);
+    return albums.map((album) => ({
+        ...album,
+        mediaItemsCount:
+            album.mediaItemsCount != null ? Number(album.mediaItemsCount) : null,
+        appCreatedAt: createdAtMap[album.id],
+    }));
 }
 
 function formatDate(value?: string | number): string {
@@ -146,7 +123,11 @@ function AlbumCard({ album }: { album: NormalizedAlbum }) {
                             </Text>
                         </View>
                     </View>
-                    {photoCount && (
+                    {/* Explicit > 0, not truthiness: a count of 0 (which every
+                        new album has) would otherwise render a bare `0` and
+                        crash with "Text strings must be rendered within a
+                        <Text> component". */}
+                    {photoCount !== null && photoCount > 0 && (
                         <View style={styles.photoBadge}>
                             <Text style={styles.photoBadgeText}>
                                 {photoCount} photo{photoCount !== 1 ? "s" : ""}
@@ -169,17 +150,9 @@ export default function AlbumsScreen() {
     const loadAlbums = useCallback(async () => {
         setError(null);
         try {
-            const token = await getValidAccessToken();
-            if (!token) {
-                setError(
-                    "Not signed in or session expired. Please sign in again.",
-                );
-                return;
-            }
-            const data = await fetchAllAlbums(token);
-            setAlbums(data);
+            setAlbums(await fetchAllAlbums());
         } catch (e) {
-            setError((e as Error).message);
+            setError(getErrorMessage(e));
         }
     }, []);
 

--- a/frontend/services/__tests__/album-service.test.ts
+++ b/frontend/services/__tests__/album-service.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { albumTitleKey, normalizeAlbumTitle } from "../album-service";
+
+jest.mock("firebase/firestore", () => ({
+    collection: jest.fn(),
+    doc: jest.fn(),
+    getDoc: jest.fn(),
+    getDocs: jest.fn(),
+    runTransaction: jest.fn(),
+    writeBatch: jest.fn(),
+    Timestamp: { now: () => ({ toMillis: () => 0 }) },
+}));
+
+describe("normalizeAlbumTitle", () => {
+    it("collapses case, surrounding space, and internal runs", () => {
+        expect(normalizeAlbumTitle("  Spring   CLEANUP  ")).toBe("spring cleanup");
+    });
+
+    it("treats case variants as the same title", () => {
+        // The original bug: albumNameExists queried a lowercased title while
+        // createEvent overwrote it with the original case, so any title with a
+        // capital letter stopped being detected as a duplicate.
+        expect(normalizeAlbumTitle("Spring Cleanup")).toBe(
+            normalizeAlbumTitle("spring cleanup"),
+        );
+    });
+});
+
+describe("albumTitleKey", () => {
+    it("is stable across case and spacing variants", () => {
+        expect(albumTitleKey("Spring  Cleanup")).toBe(albumTitleKey("spring cleanup"));
+    });
+
+    it("produces a legal Firestore id for a title containing a slash", () => {
+        const key = albumTitleKey("Zone A/B cleanup");
+        expect(key).not.toContain("/");
+        expect(key.startsWith("t_")).toBe(true);
+    });
+
+    it("escapes dots so the id is never '.' or '..'", () => {
+        expect(albumTitleKey("..")).not.toContain(".");
+    });
+
+    it("avoids the reserved __*__ id pattern", () => {
+        expect(albumTitleKey("__proto__").startsWith("t_")).toBe(true);
+    });
+
+    it("distinguishes genuinely different titles", () => {
+        expect(albumTitleKey("Cleanup A")).not.toBe(albumTitleKey("Cleanup B"));
+    });
+});
+
+// backend/scripts/backfill-firestore.ts re-implements this function to create
+// reservation documents for pre-existing albums. Both sides assert the same
+// vectors, so a divergence fails CI rather than silently re-opening the
+// duplicate-album-name hole.
+describe("shared key vectors (contract with the backfill migration)", () => {
+    type Vectors = { vectors: { title: string; key: string }[] };
+    const { vectors } = JSON.parse(
+        readFileSync(
+            resolve(__dirname, "../../../album-title-test-vectors.json"),
+            "utf8",
+        ),
+    ) as Vectors;
+
+    it("has vectors to check", () => {
+        expect(vectors.length).toBeGreaterThan(10);
+    });
+
+    it.each(vectors)("$title -> $key", ({ title, key }) => {
+        expect(albumTitleKey(title)).toBe(key);
+    });
+});

--- a/frontend/services/album-service.ts
+++ b/frontend/services/album-service.ts
@@ -1,0 +1,188 @@
+import { db } from "@/config/firebase";
+import {
+    collection,
+    doc,
+    getDoc,
+    getDocs,
+    runTransaction,
+    Timestamp,
+    writeBatch,
+} from "firebase/firestore";
+import { requireUser } from "./require-user";
+
+export const ALBUMS_COLLECTION = "albums";
+export const ALBUM_TITLES_COLLECTION = "albumTitles";
+
+export type AlbumDoc = {
+    albumId: string;
+    title: string;
+    titleLower: string;
+    albumUrl: string;
+    eventId: string | null;
+    createdBy: string;
+    createdAt: Timestamp;
+};
+
+export type AlbumReservationStatus = "pending" | "created";
+
+export type AlbumReservation = {
+    titleKey: string;
+    title: string;
+    titleLower: string;
+    albumId: string | null;
+    reservedBy: string;
+    reservedAt: Timestamp;
+    status: AlbumReservationStatus;
+};
+
+export type ReservedAlbumTitle = {
+    titleKey: string;
+    existingAlbumId: string | null;
+};
+
+export function normalizeAlbumTitle(title: string): string {
+    return title.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+// Deterministic, legal Firestore document id: encodeURIComponent escapes "/",
+// the "." replacement avoids "." and "..", and the prefix avoids the reserved
+// __*__ pattern. A deterministic id is what makes the reservation atomic.
+export function albumTitleKey(title: string): string {
+    return `t_${encodeURIComponent(normalizeAlbumTitle(title)).replace(/\./g, "%2E")}`;
+}
+
+// Claims a title before any Google Photos call. Two concurrent creators of the
+// same title cannot both pass: one commits, the other's transaction retries,
+// re-reads the now-existing doc, and throws.
+export async function reserveAlbumTitle(
+    title: string,
+): Promise<ReservedAlbumTitle> {
+    const currentUser = requireUser("create an album");
+    const titleKey = albumTitleKey(title);
+    const ref = doc(db, ALBUM_TITLES_COLLECTION, titleKey);
+
+    return runTransaction(db, async (transaction) => {
+        const snapshot = await transaction.get(ref);
+        if (snapshot.exists()) {
+            const existing = snapshot.data() as AlbumReservation;
+            if (existing.status === "created") {
+                throw new Error(`An album named "${title.trim()}" already exists.`);
+            }
+            if (existing.reservedBy !== currentUser.uid) {
+                throw new Error(
+                    `An album named "${title.trim()}" is being created by someone else.`,
+                );
+            }
+            // Our own half-finished attempt: hand the album back so a retry
+            // reuses it instead of creating a second one.
+            return { titleKey, existingAlbumId: existing.albumId };
+        }
+        transaction.set(ref, {
+            titleKey,
+            title: title.trim(),
+            titleLower: normalizeAlbumTitle(title),
+            albumId: null,
+            reservedBy: currentUser.uid,
+            reservedAt: Timestamp.now(),
+            status: "pending",
+        });
+        return { titleKey, existingAlbumId: null };
+    });
+}
+
+// Records the remote album id while the reservation is still pending. Google
+// Photos has no album-delete endpoint, so an album created before a later step
+// fails cannot be undone — recording it here lets a retry reuse it.
+export async function markAlbumCreated(
+    titleKey: string,
+    albumId: string,
+): Promise<void> {
+    requireUser("create an album");
+    await runTransaction(db, async (transaction) => {
+        const ref = doc(db, ALBUM_TITLES_COLLECTION, titleKey);
+        const snapshot = await transaction.get(ref);
+        if (!snapshot.exists()) {
+            throw new Error("Album title reservation disappeared.");
+        }
+        transaction.update(ref, { albumId });
+    });
+}
+
+export async function finalizeAlbum(args: {
+    titleKey: string;
+    albumId: string;
+    title: string;
+    albumUrl: string;
+}): Promise<void> {
+    const currentUser = requireUser("create an album");
+    const batch = writeBatch(db);
+    const album: AlbumDoc = {
+        albumId: args.albumId,
+        title: args.title.trim(),
+        titleLower: normalizeAlbumTitle(args.title),
+        albumUrl: args.albumUrl,
+        eventId: null,
+        createdBy: currentUser.uid,
+        createdAt: Timestamp.now(),
+    };
+    batch.set(doc(db, ALBUMS_COLLECTION, args.albumId), album);
+    batch.update(doc(db, ALBUM_TITLES_COLLECTION, args.titleKey), {
+        albumId: args.albumId,
+        status: "created",
+    });
+    await batch.commit();
+}
+
+// Compensation for a failed setup. Only ever releases our own still-pending
+// reservation, so it can never delete a title someone else finished with.
+export async function releaseAlbumTitle(titleKey: string): Promise<void> {
+    const currentUser = requireUser("create an album");
+    await runTransaction(db, async (transaction) => {
+        const ref = doc(db, ALBUM_TITLES_COLLECTION, titleKey);
+        const snapshot = await transaction.get(ref);
+        if (!snapshot.exists()) return;
+
+        const reservation = snapshot.data() as AlbumReservation;
+        if (reservation.status === "created") return;
+        if (reservation.reservedBy !== currentUser.uid) {
+            throw new Error("Cannot release an album title reserved by someone else.");
+        }
+        if (reservation.albumId) {
+            transaction.delete(doc(db, ALBUMS_COLLECTION, reservation.albumId));
+        }
+        transaction.delete(ref);
+    });
+}
+
+export async function albumNameExists(title: string): Promise<boolean> {
+    const snapshot = await getDoc(
+        doc(db, ALBUM_TITLES_COLLECTION, albumTitleKey(title)),
+    );
+    return (
+        snapshot.exists() &&
+        (snapshot.data() as AlbumReservation).status === "created"
+    );
+}
+
+export async function linkAlbumToEvent(
+    albumId: string,
+    eventId: string,
+    albumUrl: string,
+): Promise<void> {
+    const batch = writeBatch(db);
+    batch.update(doc(db, ALBUMS_COLLECTION, albumId), { eventId, albumUrl });
+    await batch.commit();
+}
+
+// albums.tsx pairs remote Google Photos albums with the date we recorded here.
+export async function getAlbumCreatedAtMap(): Promise<Record<string, number>> {
+    const snapshot = await getDocs(collection(db, ALBUMS_COLLECTION));
+    const map: Record<string, number> = {};
+    for (const albumDoc of snapshot.docs) {
+        const data = albumDoc.data() as Partial<AlbumDoc>;
+        if (data.createdAt) {
+            map[albumDoc.id] = data.createdAt.toMillis();
+        }
+    }
+    return map;
+}


### PR DESCRIPTION
The app called photoslibrary.googleapis.com directly with each volunteer's
personal OAuth token, so albums were created in their own Google Photos library
rather than the MVT account. Volunteers could not see each other's albums, which
defeats the shared-album design the backend exists to provide.

api/backend-client.ts reads EXPO_PUBLIC_BACKEND_URL, attaches the signed-in
user's Firebase ID token, and retries exactly once on 401 with a force-refreshed
token, since an hour-long token expiring mid-session is routine. The URL is
resolved before the try block so a misconfiguration reports itself as "not
configured" rather than a network error — a bug the tests caught.

services/album-service.ts owns the Firestore album registry and adds a
transactional title reservation on a deterministic document id, which is the
only way to get atomic check-then-act in the Firestore Web SDK. It separates the
normalized match key from the display title, so an album whose name contains a
capital letter stops being invisible to duplicate detection.

albums.tsx now lists from the proxy, so every admin sees the same albums, and
guards the photo count with an explicit > 0. A count of 0, which every new album
has, rendered a bare 0 and crashed with "Text strings must be rendered within a
<Text> component".



---

### The stack

Merge bottom-up. Each PR is reviewable alone and introduces no new typecheck errors.

| PR | Change | Files |
|----|--------|-------|
| #90 | backend: Firebase ID token auth, CORS, testable refactor | 32 |
| #91 | firestore: rules, indexes, emulator suite | 9 |
| #92 | docs + CI (backend & firestore jobs) | 5 |
| #93 | delete the Expo starter template | 15 |
| #94 | delete dead scripts + Sheets integration | 6 |
| #95 | fix the typecheck gate, add jest, commit lockfile | 7 |
| #96 | shared error/auth helpers, single Firestore handle | 4 |
| #97 | stop leaking Trello credentials; admin custom claim | 9 |
| #98 | cache Trello board/list ids; publish ordering | 7 |
| #99 | Google Photos via the backend proxy | 5 |
| #100 | event ownership, rollback-safe setup, hours of service | 9 |
| #101 | CI: add the frontend job | 1 |
| #102 | persist and upload trail photos | 8 |
| #103 | one auth subscription; delete dead token layer | 6 |
| #104 | link EAS environments to build profiles | 2 |

`origin/main` has **67 typecheck errors today**. They fall to 8 at #93, 6 at #100, and 0 at #102 — the count never rises.

CI runs from #92 onward (backend + firestore), and covers all three packages from #101.
