### PR TITLE
ci: typecheck, lint and test all three packages on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,33 @@ on:
     branches: [main]
 
 jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm test -- --ci
+        env:
+          # config/firebase.ts fails fast on missing config. These are dummy
+          # values so the module can load under test; no real project is used.
+          EXPO_PUBLIC_FIREBASE_API_KEY: test-api-key
+          EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN: test.firebaseapp.com
+          EXPO_PUBLIC_FIREBASE_PROJECT_ID: test-project
+          EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET: test.appspot.com
+          EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: "000000000000"
+          EXPO_PUBLIC_FIREBASE_APP_ID: "1:000000000000:web:test"
+
   rules:
     name: Firestore rules
     runs-on: ubuntu-latest


### PR DESCRIPTION
The backend and firestore-rules jobs landed earlier in the stack, when those
packages became complete. The frontend job could not: it needs the typecheck and
test scripts and the jest setup from the toolchain PR, and at least one frontend
test to exist or jest exits non-zero.

Both are now true, so this adds typecheck, lint and test for frontend, giving
all three packages coverage on every PR.

The dummy EXPO_PUBLIC_FIREBASE_* values exist because config/firebase.ts fails
fast on missing config; no real project is contacted.



---

### The stack

Merge bottom-up. Each PR is reviewable alone and introduces no new typecheck errors.

| PR | Change | Files |
|----|--------|-------|
| #90 | backend: Firebase ID token auth, CORS, testable refactor | 32 |
| #91 | firestore: rules, indexes, emulator suite | 9 |
| #92 | docs + CI (backend & firestore jobs) | 5 |
| #93 | delete the Expo starter template | 15 |
| #94 | delete dead scripts + Sheets integration | 6 |
| #95 | fix the typecheck gate, add jest, commit lockfile | 7 |
| #96 | shared error/auth helpers, single Firestore handle | 4 |
| #97 | stop leaking Trello credentials; admin custom claim | 9 |
| #98 | cache Trello board/list ids; publish ordering | 7 |
| #99 | Google Photos via the backend proxy | 5 |
| #100 | event ownership, rollback-safe setup, hours of service | 9 |
| #101 | CI: add the frontend job | 1 |
| #102 | persist and upload trail photos | 8 |
| #103 | one auth subscription; delete dead token layer | 6 |
| #104 | link EAS environments to build profiles | 2 |

`origin/main` has **67 typecheck errors today**. They fall to 8 at #93, 6 at #100, and 0 at #102 — the count never rises.

CI runs from #92 onward (backend + firestore), and covers all three packages from #101.
