### PR TITLE
frontend: link EAS environments to the build profiles

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -11,7 +11,6 @@
       "com.googleusercontent.apps.405328478335-4gr2n100eq9g8tg8m4r89tm26gas4rcs"
     ],
     "userInterfaceStyle": "automatic",
-   
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.anonymous.mountvernontrail"
@@ -23,7 +22,6 @@
         "backgroundImage": "./assets/images/android-icon-background.png",
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
-      
       "predictiveBackGestureEnabled": false,
       "package": "com.hack4impact.mountvernontrail",
       "permissions": [
@@ -78,6 +76,7 @@
       "eas": {
         "projectId": "a86e295c-87e9-4b44-affe-e9cbc3681824"
       }
-    }
+    },
+    "owner": "friends-of-mvt-h4i"
   }
 }

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -6,13 +6,16 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "environment": "development"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "environment": "preview"
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "environment": "production"
     }
   },
   "submit": {


### PR DESCRIPTION
app.json gains the owner field alongside the projectId main already had, so
non-interactive and CI builds resolve the project.

eas.json binds each build profile to its expo.dev environment. Local .env is not
uploaded to EAS, so without this a cloud build ships undefined Firebase config
and crashes at startup. The EXPO_PUBLIC_* values already exist in the expo.dev
environments and were simply not wired to the profiles.

ios.bundleIdentifier is deliberately left as com.anonymous.mountvernontrail,
matching main and the generated native projects. Renaming it requires updating
the iOS OAuth client in Google Cloud Console first or Google sign-in breaks;
that is a separate change.



---

### The stack

Merge bottom-up. Each PR is reviewable alone and introduces no new typecheck errors.

| PR | Change | Files |
|----|--------|-------|
| #90 | backend: Firebase ID token auth, CORS, testable refactor | 32 |
| #91 | firestore: rules, indexes, emulator suite | 9 |
| #92 | docs + CI (backend & firestore jobs) | 5 |
| #93 | delete the Expo starter template | 15 |
| #94 | delete dead scripts + Sheets integration | 6 |
| #95 | fix the typecheck gate, add jest, commit lockfile | 7 |
| #96 | shared error/auth helpers, single Firestore handle | 4 |
| #97 | stop leaking Trello credentials; admin custom claim | 9 |
| #98 | cache Trello board/list ids; publish ordering | 7 |
| #99 | Google Photos via the backend proxy | 5 |
| #100 | event ownership, rollback-safe setup, hours of service | 9 |
| #101 | CI: add the frontend job | 1 |
| #102 | persist and upload trail photos | 8 |
| #103 | one auth subscription; delete dead token layer | 6 |
| #104 | link EAS environments to build profiles | 2 |

`origin/main` has **67 typecheck errors today**. They fall to 8 at #93, 6 at #100, and 0 at #102 — the count never rises.

CI runs from #92 onward (backend + firestore), and covers all three packages from #101.
