### PR TITLE
docs: contributor guides and architecture doc (16/16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,168 @@
+# CLAUDE.md
+
+Guidance for Claude Code working in this repo.
+
+## What this is
+
+The **Friends of the Mount Vernon Trail** volunteer app (Hack4Impact-UMD). During
+a Saturday work event a volunteer documents each trail issue: photograph the
+problem, fix it, photograph it again, record metrics, then publish a summary to
+Trello.
+
+The before/after photos land in **one shared Google Photos album owned by the MVT
+account** — not in any volunteer's personal library. That single requirement is
+why `backend/` exists: the app has no Google Photos credentials and reaches the
+album only through our own proxy.
+
+## Repo shape
+
+Three **independent** npm packages. There is no root `package.json` and no
+workspace config — `npm test` at the repo root does nothing. Always `cd` into a
+package first.
+
+| Path | What | Nested guidance |
+|---|---|---|
+| `frontend/` | Expo / React Native app | [frontend/CLAUDE.md](frontend/CLAUDE.md) |
+| `backend/` | Express proxy to Google Photos | [backend/CLAUDE.md](backend/CLAUDE.md) |
+| `firestore/` | Emulator tests for `firestore.rules` | [firestore/CLAUDE.md](firestore/CLAUDE.md) |
+
+Cross-package flows (event setup saga, photo pipeline, event lifecycle) are in
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+## Commands
+
+Run every gate the package actually has, exactly as CI does on each PR.
+
+```bash
+cd frontend  && npm run typecheck && npm run lint && npm test   # 66 tests, ~1s
+cd backend   && npm run typecheck && npm run lint && npm test   # 91 tests, minutes on a cold cache
+cd firestore && npm run typecheck && npm test                   # 35 tests, ~3s + emulator boot
+```
+
+`firestore/` has no `lint` script — it is two gates there, not three.
+
+Two things that will otherwise waste your time:
+
+- **The backend suite can take several minutes.** It is CPU-bound, not waiting on
+  anything: `jest.config.js` uses the `ts-jest` preset, so every suite is
+  typechecked as it is transformed. The first run after a fresh clone or a cleared
+  jest cache is the slow one; later runs are far quicker. It is not hung — do not
+  kill it.
+- **The rules suite starts and stops its own emulator** via
+  `firebase emulators:exec`. Do not launch an emulator by hand; you will get a
+  port conflict. It needs Java, no credentials, and no live Firebase project.
+
+CI is [.github/workflows/ci.yml](.github/workflows/ci.yml) — three independent
+jobs on every pull request and every push to `main`, Node 22, plus Temurin 17 for
+the rules job. The backend job also runs `npm run build`.
+
+## The three systems
+
+One user flow spans three backends, each reached a different way:
+
+| System | How it is reached | Enforced by |
+|---|---|---|
+| **Firestore** | directly from the device, Firebase web SDK v11 | [firestore.rules](firestore.rules) |
+| **Google Photos** | only via `backend/`, never directly | Firebase ID token, then the MVT refresh token |
+| **Trello** | directly from the device, per-volunteer OAuth token | Trello |
+
+## Data model
+
+Three collections. Types live in
+[frontend/services/event-service.ts](frontend/services/event-service.ts) and
+[frontend/services/album-service.ts](frontend/services/album-service.ts).
+
+**`events/{eventId}`** — `eventId`, `title`, `description`, `date`,
+`trelloCardId`, `albumId`, `albumUrl`, `createdBy` (the admin who set it up),
+`startedBy` (the volunteer running it, `null` until claimed), `startDate`,
+`endDate`, `isActive`, `isDraft`, `savedAsDraftAt`, `publishedAt?`, `createdAt`,
+`eventLeader`, `zoneLeaders`, `toolHaulers`, `gloverLover`, `notes`, `metrics?`.
+
+`createdBy` and `startedBy` are deliberately separate people.
+
+**`EventMetrics`** is exactly 15 numeric keys: `drainageCleaned`,
+`graffitiTagsRemoved`, `stickersRemoved`, `otherImprovements`, `itemsPainted`,
+`pressureWashed`, `itemsRepaired`, `safetyImprovements`, `snowRemovalEvents`,
+`potholesFilled`, `trailEdgedFeet`, `trashBagsCollected`, `trashPoundsCollected`,
+`treesTrimmed`, `vegetationVolunteers`. Every key must have a matching input in
+`components/ui/trail-metrics-section.tsx` — a test asserts it.
+
+`hoursOfService` is **derived** from `endDate - startDate` by
+`extractMetricsWithHours`, never stored. `endDate` is written exactly once, when
+the event ends; `saveDraft` and `publishEvent` must never touch it, or re-saving a
+draft inflates the hours.
+
+**`albums/{albumId}`** — `albumId`, `title`, `titleLower`, `albumUrl`, `eventId`,
+`createdBy`, `createdAt`.
+
+**`albumTitles/{titleKey}`** — `titleKey`, `title`, `titleLower`, `albumId`,
+`reservedBy`, `reservedAt`, `status` (`"pending" | "created"`). The document id is
+deterministic, which is what makes the duplicate-title check atomic.
+
+## Security boundary
+
+**[firestore.rules](firestore.rules) is the only real enforcement.**
+`requireUser()` in
+[frontend/services/require-user.ts](frontend/services/require-user.ts) is a UX
+guard that produces a friendly error — it is not a security control. Never rely on
+a client-side check to protect data.
+
+There is exactly one custom claim, `admin`:
+
+```bash
+cd backend && npm run set-admin -- you@example.com
+```
+
+Sign out and back in afterwards — ID tokens cache claims for up to an hour, so the
+claim does not take effect until the token is reissued.
+
+## Firestore indexes
+
+Any new **compound** query (a `where` plus an `orderBy`, or two `where`s on
+different fields) needs an entry in
+[firestore.indexes.json](firestore.indexes.json) or it throws
+`failed-precondition` in a fresh environment. Three exist today, all on `events`:
+
+- `startedBy, endDate, startDate desc` — backs `getActiveEvent()`
+- `isDraft, startedBy, savedAsDraftAt desc` — backs `getDraftEvents()`
+- `isDraft, savedAsDraftAt desc` — retained from the pre-ownership schema so a
+  rollback still has its index
+
+Deploy with `npx firebase deploy --only firestore:indexes` and wait for every
+index to report `READY` **before** deploying rules. Check readiness with
+`npx firebase firestore:indexes --pretty` — **the `--pretty` flag is required**,
+because the default JSON output omits the `state` field entirely and so lists a
+still-building index indistinguishably from a ready one.
+
+## Which docs to trust
+
+| Doc | Status |
+|---|---|
+| [README.md](README.md) | Current — setup, migration runbook, git procedures |
+| [backend/README.md](backend/README.md) | Current — endpoint table, OAuth linking, deployment |
+| [MANUAL_TEST_PLAN.md](MANUAL_TEST_PLAN.md) | Current — the flows needing real credentials |
+| [PROJECT_AUDIT.md](PROJECT_AUDIT.md) | **Historical (2026-08-06)** — describes the pre-refactor code |
+| [FEATURE_PROPOSALS.md](FEATURE_PROPOSALS.md) | **Historical (2026-08-06)** — premises partly obsolete |
+
+The audit and the proposals were written before the `stack/01`–`stack/15` refactor
+series. Most of the audit's findings are fixed, and the proposals' top-ranked
+feature is built on a Google Sheets client that has since been deleted. Both carry
+a banner saying so. **Do not treat either as a current to-do list** — check the
+code before acting on anything in them.
+
+## Conventions
+
+The root [.prettierrc](.prettierrc) governs all three packages: 4-space indent,
+double quotes, semicolons, `bracketSameLine: true`, `singleAttributePerLine: true`.
+A few older files (`frontend/constants/theme.ts`, `frontend/app/camera-view.tsx`)
+predate it and are unformatted — leave them unless you are already editing them.
+
+- `type` over `interface`; no `enum` — use string literal unions.
+- `catch (error: unknown)`, then a shared error helper. Never swallow an exception.
+- One typed error class per domain rather than generic `Error`.
+- Comments explain **why**, and often name the bug they fixed. Match that register;
+  do not add narration that restates the code.
+- Branches are `feature/...` or `bugfix/...`. Never commit to `main`.
+- PR reviewers: `bsthapar`, `asea-aranion`.
+
+Run all three gates before opening a PR.

--- a/FEATURE_PROPOSALS.md
+++ b/FEATURE_PROPOSALS.md
@@ -1,5 +1,10 @@
 # Feature Proposals — mount-vernon-trail
 
+> **Historical document — premises partly obsolete.** Written 2026-08-06, before
+> the `stack/01`–`stack/15` refactor series. Some proposals build on code that has
+> since been deleted (notably the Google Sheets client). Re-check feasibility
+> against the current code before picking anything up.
+
 **Date:** 2026-08-06 · Companion to [PROJECT_AUDIT.md](PROJECT_AUDIT.md). Features proposed from research into the real organization's operations plus a full codebase inventory, generated through four lenses (field volunteer, event leader, admin/impact, integrations & automation) and then deduplicated, feasibility-checked, and ranked. Every "builds on" claim below was verified against the actual code.
 
 ## How to read this

--- a/PROJECT_AUDIT.md
+++ b/PROJECT_AUDIT.md
@@ -1,5 +1,10 @@
 # Project Audit — mount-vernon-trail
 
+> **Historical document — not a to-do list.** This is a point-in-time snapshot of
+> the code as it stood on 2026-08-06, before the `stack/01`–`stack/15` refactor
+> series. Most findings below have since been fixed. Check the current code before
+> acting on anything here.
+
 **Date:** 2026-08-06 · **Scope:** full repo (frontend app, backend proxy, config, git/GitHub state) · **Method:** 14-agent read-only audit — every screen/component/service/auth file read, `tsc --noEmit` + ESLint run against the repo's own toolchain, GitHub state verified via `gh` API. All findings marked **✓ verified** were independently re-confirmed by an adversarial second pass.
 
 ## 1. Summary

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ users out of their own existing events.
 cd backend && npm run snapshot -- backup
 
 # 1. Indexes, and wait until every one reports READY.
+#    --pretty is required: without it the output omits `state`, so a
+#    still-building index looks exactly like a ready one.
 npx firebase deploy --only firestore:indexes
-npx firebase firestore:indexes
+npx firebase firestore:indexes --pretty
 
 # 2. Backfill. Dry-run prints the exact plan and writes nothing.
 cd backend

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,129 @@
+# backend/ — Google Photos proxy
+
+Express 5 + TypeScript (NodeNext), deployed on Render. See the root
+[CLAUDE.md](../CLAUDE.md) for repo-wide context and
+[README.md](README.md) for the full endpoint table, the one-time Google account
+linking, and deployment settings — this file covers what to know before editing.
+
+## Why this service exists
+
+Every volunteer's before/after photos must land in **one shared album owned by the
+MVT Google account**. No volunteer can own that album, and the app cannot hold the
+MVT credentials. So the app authenticates to *this* service, and this service holds
+the single Google refresh token.
+
+Two independent auth layers:
+
+| Layer | Who | Mechanism |
+|---|---|---|
+| caller → this API | every volunteer | `Authorization: Bearer <Firebase ID token>` on all `/api/*` |
+| this API → Google Photos | the MVT account, once | admin OAuth flow, refresh token in Redis (+ env backup) |
+
+```bash
+npm run dev        # tsx watch
+npm run build      # tsc -> dist/
+npm start          # run the build
+npm run typecheck  # tsc --noEmit
+npm run lint       # eslint .
+npm test           # jest + supertest — 91 tests, minutes on a cold cache
+```
+
+**The suite is slow but never hung.** Nothing in it sleeps — TTL and expiry
+behavior is exercised through injected clocks (`createInMemoryStore(() => now)`),
+not real timers. The cost is `ts-jest`: `jest.config.js` uses that preset, so every
+suite is typechecked as it is transformed. A fresh clone or a cleared jest cache
+pays that in full; later runs reuse it and finish far quicker. Do not kill it.
+
+## Shape to preserve
+
+`createApp(env, auth, tokenStore)` in [src/app.ts](src/app.ts) is exported so
+supertest can drive the real app with fakes. [src/index.ts](src/index.ts) does
+nothing but load env, construct dependencies, and listen.
+
+**Keep new code injectable the same way.** Reaching for a module-level singleton or
+reading `process.env` deep in a handler is what makes `app.test.ts` — the suite
+covering auth, CORS, uploads and the admin OAuth bootstrap — impossible to write.
+
+## Auth
+
+[src/middleware/auth.ts](src/middleware/auth.ts) exports `requireFirebaseAuth(auth)`
+and `requireAdmin`. All of `/api/*` is already mounted behind
+`requireFirebaseAuth`, so a new `/api` route inherits it — do not re-add it.
+
+`GET /auth/callback` is deliberately **not** behind Firebase auth: Google's
+redirect cannot send an `Authorization` header. It is authenticated instead by a
+single-use `state` nonce stored in Redis with a 600s TTL. Do not "fix" this by
+adding the middleware.
+
+`requireAdmin` checks the `admin` custom claim, set by
+[scripts/set-admin-claim.ts](scripts/set-admin-claim.ts).
+
+## Token store
+
+[src/google-tokens.ts](src/google-tokens.ts). Access-token lookup order:
+
+```
+per-process memory cache  →  Redis (if ttl > 60s)  →  refresh
+```
+
+Refresh-token lookup order: Redis → the `GOOGLE_REFRESH_TOKEN` env var, which then
+re-seeds Redis. That env fallback exists because a wiped free-tier Redis would
+otherwise force an admin to redo the whole OAuth dance. Concurrent refreshes are
+collapsed by an `inflight` promise.
+
+Upstash is **optional locally** (falls back to an in-memory store with a warning)
+and **required when `NODE_ENV=production`** — [src/env.ts](src/env.ts) refuses to
+boot without it.
+
+Env loading fails fast and names **every** missing variable at once. Keep that
+behavior when adding a variable; see [.env.example](.env.example), which documents
+all of them.
+
+## Uploads
+
+[src/routes/api.ts](src/routes/api.ts), `POST /api/upload`:
+
+- multer `memoryStorage`, bounded concurrency of 4 via
+  [src/concurrency.ts](src/concurrency.ts)
+- `201` every photo uploaded · `207` partial, casualties named in `failed[]` ·
+  `502` none uploaded (the `batchCreate` is skipped entirely)
+
+Partial-failure tolerance is deliberate: one bad photo must not strand the rest of
+a volunteer's event.
+
+The **whole request is buffered in memory**, so `MAX_UPLOAD_FILES` ×
+`MAX_UPLOAD_BYTES_PER_FILE` (default 10 × 10 MB) is a memory ceiling, not a policy
+preference. Raising it on a 512 MB Render instance risks an OOM.
+
+## Gotchas
+
+- **`tsconfig.json` `include` is `src/**/*` only, so `npm run typecheck` does not
+  cover `scripts/`** — even though those scripts import from `../src/`.
+  `npm run lint` does cover them. Check a script edit with lint, or by running it
+  in dry-run mode.
+- `jest.config.js` sets `roots: ["<rootDir>/src"]`, so `scripts/` has no tests.
+- `backfill`, `snapshot restore` and `triage --delete` are **dry-run by default**
+  and require `--apply` to write. Read the dry-run output before applying;
+  `backfill` prints a `REVIEW THESE` section for ambiguous documents.
+- **`set-admin` is the exception — it has no dry run.** It takes only `<email>`,
+  `--revoke` and `--list`, and a bare invocation grants the claim against the live
+  project immediately. Passing `--apply` does not gate anything; it is ignored as a
+  stray argument. Use `--list` first if you want to look before you write.
+- Firestore is touched **only** from `scripts/`, never from `src/`. The service
+  itself is stateless apart from the token store.
+- Trello is not called from this service at all — it lives entirely in
+  `frontend/services/trello-*.ts`.
+
+## Parity constraint
+
+[src/album-title-key.ts](src/album-title-key.ts) deliberately mirrors
+`normalizeAlbumTitle` / `albumTitleKey` in
+[../frontend/services/album-service.ts](../frontend/services/album-service.ts).
+Both are pinned to
+[../album-title-test-vectors.json](../album-title-test-vectors.json), asserted by
+`src/__tests__/album-title-parity.test.ts` on this side and
+`services/__tests__/album-service.test.ts` on the other.
+
+**Change one and you must change the other.** If they drift, event setup and the
+backfill migration compute different document ids for the same album title, and
+the duplicate-title check silently stops working.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,186 @@
+# Architecture
+
+The flows that cross package boundaries. Per-package detail lives in
+[../frontend/CLAUDE.md](../frontend/CLAUDE.md),
+[../backend/CLAUDE.md](../backend/CLAUDE.md) and
+[../firestore/CLAUDE.md](../firestore/CLAUDE.md).
+
+## The systems
+
+```mermaid
+graph LR
+    App["frontend/<br/>Expo app"]
+    FS[("Firestore<br/>events · albums · albumTitles")]
+    BE["backend/<br/>Express proxy"]
+    GP["Google Photos<br/>MVT-owned album"]
+    TR["Trello<br/>MVT board"]
+
+    App -->|"Firebase web SDK<br/>gated by firestore.rules"| FS
+    App -->|"Bearer Firebase ID token"| BE
+    BE -->|"MVT refresh token"| GP
+    App -->|"per-volunteer OAuth token"| TR
+```
+
+Firestore and Trello are reached **directly from the device**. Google Photos never
+is — that indirection is the reason `backend/` exists.
+
+## Sign-in and roles
+
+Volunteers sign in with Google through Firebase Auth.
+[frontend/auth/auth-context.tsx](../frontend/auth/auth-context.tsx) holds the
+single app-wide subscription; `user` is `undefined` while initializing, `null`
+when signed out, a `User` when signed in.
+
+There is exactly one role, carried as the Firebase custom claim `admin`:
+
+```bash
+cd backend && npm run set-admin -- you@example.com
+```
+
+**The claim only reaches the app when a new ID token is minted**, and tokens are
+cached for up to an hour. Signing out and back in is a required step, not a
+suggestion. `useIsAdmin()` reads the cached token first and force-refreshes only
+when it reports non-admin.
+
+Admins can create events, create albums, and view the albums screen. Everything
+else is open to any signed-in volunteer, and the boundary is enforced in
+[firestore.rules](../firestore.rules) — never client-side.
+
+## Event setup is a saga
+
+Creating an event writes to three systems that have no shared transaction. A
+failure partway used to leave orphans behind, and — worst of all — an orphaned
+album record permanently blocked ever reusing that title.
+
+[frontend/services/event-setup.ts](../frontend/services/event-setup.ts) now runs
+each step with a registered undo, unwinding in reverse on failure.
+
+```mermaid
+sequenceDiagram
+    participant UI as setup-event screen
+    participant FS as Firestore
+    participant BE as backend
+    participant TR as Trello
+
+    UI->>FS: 1. reserveAlbumTitle(title)
+    Note over UI,FS: claimed first — a collision now costs zero external calls
+    UI->>BE: 2. createAlbum (or getAlbum if retrying)
+    BE->>BE: Google Photos, MVT account
+    UI->>FS: 3. markAlbumCreated + finalizeAlbum
+    Note over UI,FS: must precede createEvent, whose batch updates this doc
+    UI->>TR: 4. createEventCard
+    UI->>TR: 5. addAlbumLinkToCard
+    UI->>FS: 6. createEvent
+```
+
+Two design points worth keeping:
+
+- **The title is claimed before anything external happens.** A duplicate title
+  fails immediately instead of after creating a Google album and a Trello card.
+- **A retry reuses the album from a failed attempt** rather than creating a second
+  one, because the Google Photos API has no album-delete endpoint. The reservation
+  carries `existingAlbumId` for exactly this.
+
+When unwinding cannot fully succeed, `EventSetupError.residue` carries what was
+left behind and is appended to the user-facing message — a partial failure is
+never silent.
+
+## Event lifecycle
+
+```
+admin creates          volunteer claims        volunteer works        stop           publish
+  (unstarted)     →      (startedBy set)   →    (metrics, photos)  →  (ended)   →   (published)
+```
+
+| Transition | Writes | Gated by |
+|---|---|---|
+| create | `createdBy`, all start/end fields null | admin only |
+| claim | `startDate`, `startedBy`, `isActive` | any signed-in user, **only if unclaimed** |
+| running | `metrics`, `notes` | admin or `startedBy` |
+| end | `isActive: false`, `endDate` | admin or `startedBy` |
+| draft | `isDraft`, `savedAsDraftAt` | admin or `startedBy` |
+| publish | `isDraft: false`, `publishedAt` | admin or `startedBy` |
+
+`endDate` is written **exactly once**, when the event ends. `saveDraft` and
+`publishEvent` must never touch it — otherwise re-saving a draft days later
+inflates `hoursOfService`, which is derived as `endDate - startDate` and never
+stored. A test in `services/__tests__/event-service.test.ts` pins this.
+
+Events are never deletable, by anyone, by rule.
+
+`notepad` was merged into `notes` on `main` and no longer exists on the `Event`
+type, but it survives in the `firestore.rules` update allowlist. That is harmless —
+an allowed key nothing writes — so it stays until someone confirms no deployed
+build still sends it.
+
+If the app is killed mid-event, [frontend/app/_layout.tsx](../frontend/app/_layout.tsx)
+calls `getActiveEvent()` once per sign-in and offers to resume. That query is
+scoped to `startedBy == currentUser.uid`, so nobody is ever dropped into someone
+else's event.
+
+## Photo pipeline
+
+The flow the project exists for. Capture must never block on the network —
+volunteers work in spotty riverside coverage — so photos are persisted locally
+first and uploaded opportunistically.
+
+```mermaid
+graph LR
+    C["camera-view<br/>capture"] --> Q[("photo queue<br/>AsyncStorage<br/>photo-queue:v1")]
+    Q -->|"flushInBackground<br/>after capture"| BC["api/backend-client<br/>uploadPhotos"]
+    Q -->|"await flush()<br/>on Stop"| BC
+    BC -->|"POST /api/upload<br/>Bearer ID token"| BE["backend"]
+    BE -->|"MVT refresh token"| GP["Google Photos<br/>shared album"]
+```
+
+- **Queue** — [frontend/services/photo-queue.ts](../frontend/services/photo-queue.ts).
+  Photo ids are deterministic (`${eventId}:${issueId}:${slot}`), so retaking a
+  photo replaces the entry instead of accumulating duplicates. Status is
+  `pending | uploaded | failed`; failures stay queued and are retryable.
+- **Opportunistic flush** — `flushInBackground(eventId)` fires after a capture in
+  [frontend/app/camera-view.tsx](../frontend/app/camera-view.tsx).
+- **Blocking flush** — `handleStop()` in
+  [frontend/app/trail-document-screen.tsx](../frontend/app/trail-document-screen.tsx)
+  awaits `flush()` before the summary appears, so an event does not end with
+  photos still stranded on the device.
+- **Upload** — `POST /api/upload` uploads with bounded concurrency 4, then issues
+  one `batchCreate`. It answers `201` (all), `207` (partial, casualties named in
+  `failed[]`), or `502` (none — `batchCreate` skipped). One bad photo never
+  strands the rest.
+
+## Album title uniqueness
+
+Album titles must be unique, case- and whitespace-insensitively, forever. The
+mechanism is a deterministic document id in `albumTitles`:
+
+```
+"Spring Cleanup " → normalize → "spring cleanup" → encode → "t_spring%20cleanup"
+```
+
+Because the id is derived from the title, a duplicate is a document-id collision —
+atomic, with no read-then-write race. A `pending` reservation can be released; a
+`created` one is permanent.
+
+The same function is implemented **twice**, in
+[frontend/services/album-service.ts](../frontend/services/album-service.ts) and
+[backend/src/album-title-key.ts](../backend/src/album-title-key.ts), pinned to the
+shared vectors in
+[album-title-test-vectors.json](../album-title-test-vectors.json). Change one and
+you must change the other.
+
+## Publish ordering
+
+In [frontend/app/edit-draft.tsx](../frontend/app/edit-draft.tsx), publishing runs
+**Trello first, Firestore last**:
+
+1. `moveCardToCompleted(...)`
+2. `moveCardAttachmentsToCompleted(...)`
+3. `publishEvent(eventId)`
+
+If a Trello call fails, the event is still `isDraft: true` and still visible in
+Drafts, so the volunteer can retry. The reverse order — which this replaced —
+flipped Firestore first, so a Trello failure left an event published in the app,
+gone from Drafts, and never moved on the board, with no way to retry from the UI.
+
+The same reasoning applies anywhere else you sequence a multi-system write: **make
+the recoverable, externally-visible step first and the local state flip last.**

--- a/firestore/CLAUDE.md
+++ b/firestore/CLAUDE.md
@@ -1,0 +1,94 @@
+# firestore/ — security rules tests
+
+**This package contains no application code.** It exists only to test
+[../firestore.rules](../firestore.rules), which lives at the repo root alongside
+[../firestore.indexes.json](../firestore.indexes.json) and
+[../firebase.json](../firebase.json).
+
+```bash
+npm test        # 35 tests, ~3s plus emulator boot
+npm run typecheck
+```
+
+`npm test` runs `firebase emulators:exec`, which **boots the Firestore emulator,
+runs jest against it, and shuts it down**. Do not start an emulator yourself —
+you will get a port conflict on 8085.
+
+Requirements: **Java** (the emulator is a Java process; CI installs Temurin 17).
+No credentials, no live Firebase project — it runs against the throwaway project
+id `mvt-rules-test`. `firebase-tools` is a local devDependency, so use
+`npx firebase`, not a global install.
+
+`jest.config.js` sets `maxWorkers: 1` because emulator state is shared across
+tests. Keep it — parallel workers will clobber each other's fixtures.
+
+## The rules model
+
+Helpers in [../firestore.rules](../firestore.rules): `isSignedIn()`, `isAdmin()`
+(the `admin` custom claim), and `changed()` (which keys a write touches).
+
+**`/events/{eventId}`**
+- **read** — any signed-in user. Deliberate: the home-screen pre-start modal must
+  read an admin-created event the volunteer has never touched.
+- **create** — admin only, must self-attribute `createdBy`, and the event must be
+  unstarted (`startedBy`, `startDate`, `endDate` all null).
+- **update (claim)** — any signed-in user may claim an **unclaimed** event, and
+  only by setting `startDate`, `startedBy`, `isActive` with `startedBy` as
+  themselves. This is how a volunteer starts an event.
+- **update (running)** — the admin or the volunteer in `startedBy`, restricted to
+  `metrics`, `notepad`, `notes`, `isActive`, `isDraft`, `endDate`,
+  `savedAsDraftAt`, `publishedAt`. `createdBy` and `startedBy` can never be
+  rewritten, and neither can `title`.
+- **delete** — denied for everyone, including admins.
+
+**`/albums/{albumId}`** — signed-in read; create/update/delete by the **owning
+admin** only (`createdBy == request.auth.uid`).
+
+**`/albumTitles/{titleKey}`** — signed-in read; an admin reserves as `pending`;
+only the holder may finalize to `created`; a `pending` reservation can be released
+but a `created` one is permanent, which is what keeps album titles unique forever.
+
+Everything else is denied by a catch-all `match /{document=**}`.
+
+Dotted writes like `metrics.trashBagsCollected` report to the rules as the single
+affected key `metrics` — that is why the update rule lists `metrics` and not each
+metric.
+
+`notepad` in that allowlist is a leftover: the field was merged into `notes` and
+nothing in the app writes it any more. An allowed key nobody sends costs nothing,
+so it stays rather than being removed in a rules change nobody needs.
+
+## Rule for changes
+
+**Any change to `firestore.rules` gets a test here.** This suite is the only thing
+between a rules edit and locking every volunteer out of production. Add the
+positive case *and* the denial case — most of the existing 35 tests are denials.
+
+Test identities are set up in [__tests__/rules.test.ts](__tests__/rules.test.ts):
+`admin-uid`, `other-admin-uid`, `volunteer-uid`, `stranger-uid`. `admin()` uses
+`authenticatedContext(uid, { admin: true })`; seed fixtures through
+`withSecurityRulesDisabled`.
+
+## Known stale comment
+
+The header of [../firestore.rules](../firestore.rules) says to test with
+`firebase emulators:exec --only firestore,auth "npm run test:rules"`. There is no
+`test:rules` script anywhere, and the real command uses `--only firestore` (no auth
+emulator — `@firebase/rules-unit-testing` mints auth contexts locally). The
+`package.json` script is the truth.
+
+## Deploying
+
+From the repo root, indexes first and only then rules — rules deployed ahead of a
+backfill can lock users out of their own existing events:
+
+```bash
+npx firebase deploy --only firestore:indexes
+npx firebase firestore:indexes --pretty   # wait for every index to report READY
+npx firebase deploy --only firestore:rules
+```
+
+**`--pretty` is not cosmetic — it is the whole point of that middle line.** Without
+it the CLI prints `{collectionGroup, queryScope, fields}` per index and drops
+`state` altogether, so a `CREATING` index is indistinguishable from a `READY` one
+and you will deploy rules early against indexes that do not exist yet.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,141 @@
+# frontend/ — Expo app
+
+Expo ~54, React Native 0.81, React 19.1, expo-router 6, TypeScript strict,
+`@/*` path alias mapped to this directory. See the root
+[CLAUDE.md](../CLAUDE.md) for the data model and cross-package context.
+
+```bash
+npm start          # expo start
+npm run ios        # expo run:ios
+npm run android    # expo run:android
+npm run typecheck  # tsc --noEmit
+npm run lint       # eslint .
+npm test           # jest — 66 tests, ~1s
+npm run format     # prettier --write .
+```
+
+There is no `build` script; native and cloud builds go through EAS profiles in
+[eas.json](eas.json).
+
+## Adding a screen — read this first
+
+Routing is **flat** file-based over the 14 files in [app/](app/). No route
+groups, no dynamic segments. Screen state travels as **query params** via
+`useLocalSearchParams`, not path segments.
+
+**Every new screen in `app/` must also be added to `AUTH_ROUTES` in
+[app/_layout.tsx](app/_layout.tsx), or a signed-in user who navigates to it is
+silently bounced back to `/home-screen`.** There is no error and nothing in the
+console — the screen just never appears. This is the single most common way to
+break this app.
+
+`index` is deliberately absent from that list; that omission is what makes `/`
+forward to `/home-screen`.
+
+The gate itself: `user === undefined` means auth is still initializing, `null`
+means signed out, a `User` means signed in. Signed out and not in
+`NON_AUTH_ROUTES` → `/auth`. Signed in and not in `AUTH_ROUTES` → `/home-screen`.
+
+## State
+
+**There is no global state library** — no Redux, zustand, jotai or MobX, and no
+`store/` directory. Do not add one without a strong reason. State is three things
+plus per-screen `useState`:
+
+1. **`AuthProvider` context** — [auth/auth-context.tsx](auth/auth-context.tsx).
+   The app-wide auth subscription. Read it with `useAuth()`.
+2. **The photo queue** — [services/photo-queue.ts](services/photo-queue.ts). A
+   module-level pub/sub store persisted to AsyncStorage under `photo-queue:v1`.
+   Bridged to React by [hooks/use-photo-queue.ts](hooks/use-photo-queue.ts).
+3. **The Trello id cache** — [services/trello-config.ts](services/trello-config.ts).
+   15-minute TTL, single-flighted, invalidated on `TrelloAuthError`.
+
+## Reuse these — do not re-implement
+
+| Need | Use | From |
+|---|---|---|
+| Firestore / auth handle | `db`, `auth`, `firebaseApp` | [config/firebase.ts](config/firebase.ts) |
+| Error message from `unknown` | `getErrorMessage` | [utils/errors.ts](utils/errors.ts) |
+| Signed-in guard | `requireUser` | [services/require-user.ts](services/require-user.ts) |
+| Colors | `Palette` | [constants/theme.ts](constants/theme.ts) |
+| Date parse / format | `parseAndValidateDate`, `getDateString` | [utils/date.ts](utils/date.ts) |
+| Anything Google Photos | the backend client | [api/backend-client.ts](api/backend-client.ts) |
+
+[config/firebase.ts](config/firebase.ts) is the **only** place Firebase is
+initialized. Never call `getFirestore()` again — import `db`. Note that this
+module **throws at import time** if any `EXPO_PUBLIC_FIREBASE_*` var is missing,
+which is why tests mock it and why CI passes dummy values.
+
+[api/backend-client.ts](api/backend-client.ts) is the **only** route to Google
+Photos. Never call `photoslibrary.googleapis.com` from the app — the whole point
+of the proxy is that photos land in the MVT account, not a volunteer's personal
+library. The client attaches the Firebase ID token and retries exactly once on a
+401 with a force-refreshed token, rebuilding the multipart body because a consumed
+stream cannot be replayed.
+
+`Palette` is the source of truth for color. Several screens still hardcode hex
+(`event-summary.tsx` has its own `PURPLE`); prefer `Palette` in new code.
+
+## Photo queue semantics
+
+Capture must never block on the network — volunteers work in spotty riverside
+coverage. A photo is written to the queue the moment it is taken and uploaded
+opportunistically, again when the event stops.
+
+Photo ids are deterministic: `${eventId}:${issueId}:${slot}`. Retaking a photo
+therefore **replaces** the queued entry rather than accumulating duplicates. Keep
+that property if you touch the id scheme.
+
+## Conventions actually used here
+
+- **Filenames are kebab-case throughout**, including components:
+  `trail-event-card.tsx`, `use-photo-queue.ts`. No PascalCase filenames.
+- Symbols are PascalCase and often differ from the filename (`header.tsx` exports
+  `HomeHeader`). Most `components/ui/*` default-export; three named-export
+  (`PastEventsCard`, `TrailDocIssuesCard`, `UpcomingEventsCard`).
+- **Styling is `StyleSheet.create` only.** No NativeWind, no Tailwind, no
+  styled-components, no `className`. Do not introduce one.
+- `type` strongly preferred over `interface` (`interface` survives only in
+  `services/trello-types.ts` and some older prop types).
+- `any` is close to eliminated — keep it that way. Catch as
+  `catch (error: unknown)` and funnel through `getErrorMessage`.
+- One typed error class per domain: `AuthError`, `TrelloAuthError`,
+  `BackendError`, `EventSetupError`. Each sets `this.name`.
+- `@/` for cross-directory imports, `./` for siblings.
+
+## Tests
+
+Tests live in `__tests__/` next to the source they cover. `jest-expo` preset.
+
+[jest.setup.js](jest.setup.js) mocks `@/config/firebase` (which throws on missing
+env) and every native module with no JS implementation under the test runtime. **A
+new native dependency usually needs a mock added there**, or unrelated suites start
+failing at import.
+
+Existing coverage: `api/__tests__/backend-client.test.ts`,
+`services/__tests__/event-service.test.ts`,
+`services/__tests__/photo-queue.test.ts`,
+`services/__tests__/album-service.test.ts`,
+`components/ui/__tests__/trail-metrics-section.test.tsx`.
+
+`album-service.test.ts` loads
+[../album-title-test-vectors.json](../album-title-test-vectors.json) — a shared
+contract with the backend. See [../backend/CLAUDE.md](../backend/CLAUDE.md).
+
+## Dead code — do not mistake these for live paths
+
+- [services/google-photos-api-service.ts](services/google-photos-api-service.ts)
+  has **zero importers** and still uses the retired `x-api-key` scheme against an
+  env var that is not in `.env.example`. It is a leftover, not the upload path.
+- [profile-pictures/](profile-pictures/) is team headshots for the root README.
+  No code references it; it is not an app asset directory.
+
+## Config
+
+All runtime config is `EXPO_PUBLIC_*` and therefore **inlined into the shipped JS
+bundle** — never put a secret in `.env`. See [.env.example](.env.example), which
+documents every variable.
+
+Local `.env` is **not** uploaded to EAS. Cloud builds read the expo.dev
+environment matching the profile in [eas.json](eas.json); a variable missing there
+ships as undefined and the app throws at startup from `config/firebase.ts`.


### PR DESCRIPTION
**Stack position: 16 of 16.** Base is `stack/15-app-config` (#104). Documentation only — no code, no config, no behavior change.

## What this adds

The repo has never had contributor documentation. This adds five files:

| File | Covers |
|---|---|
| `CLAUDE.md` | repo shape, the three-systems picture, data model, security boundary, conventions |
| `backend/CLAUDE.md` | the two auth layers, token store, upload limits, script safety |
| `frontend/CLAUDE.md` | routing gate, state, what to reuse, dead code, test setup |
| `firestore/CLAUDE.md` | the rules model, emulator workflow, deploy order |
| `docs/ARCHITECTURE.md` | the flows that cross package boundaries |

The aim is the things that are invisible in the code and expensive to rediscover:

- **A new screen not added to `AUTH_ROUTES` silently bounces to `/home-screen`.** No error, nothing in the console.
- **The album title key is implemented twice** — `frontend/services/album-service.ts` and `backend/src/album-title-key.ts` — pinned to shared vectors. If they drift, event setup and the backfill compute different document ids for the same title and the duplicate check stops working.
- **`endDate` is written exactly once.** `saveDraft` and `publishEvent` must never touch it, or re-saving a draft inflates `hoursOfService`.
- **Publishing runs Trello first, Firestore last**, so a Trello failure leaves the event retryable in Drafts.

## These were fact-checked, not just written

Every objectively checkable claim was verified against this tree — file paths, exported symbols, test counts, ports, timeouts, size limits, npm scripts, tsconfig/jest/eslint assertions, HTTP status codes, and each "X is the only importer of Y". **216 claims checked; 4 were wrong.** All four are corrected here rather than shipped, and each one would have actively misled a reader:

**`set-admin` is not dry-run.** `backend/CLAUDE.md` claimed all four scripts are dry-run by default. `set-admin-claim.ts` parses only `<email>`, `--revoke` and `--list`, then calls `setCustomUserClaims` immediately; `--apply` is silently ignored as a stray argument. The old text told you that you were previewing a write to the `admin` claim — the single custom claim gating admin-only writes in `firestore.rules`, i.e. the repo's only real security boundary.

**The backend suite is not waiting on timers.** Both CLAUDE.md files blamed the runtime on `google-tokens.test.ts` and `kv-store.test.ts` "waiting on real timers". Neither sleeps — `kv-store.test.ts` injects a clock (`createInMemoryStore(() => now)`) and advances a variable. The cost is `ts-jest` typechecking each suite as it transforms it, which is why a cold cache is slow and later runs are not. Anyone acting on the old text would have opened those two files hunting a timer that isn't there.

**`firestore:indexes` needs `--pretty`.** Both `firestore/CLAUDE.md` and `README.md`'s migration runbook used it without the flag. In the pinned firebase-tools 13.35.1, `makeIndexSpec()` rebuilds each entry as `{collectionGroup, queryScope, fields}` and drops `state`; `[READY]`/`[CREATING]` is printed only via `pretty-print.js`, reachable only with `--pretty`. So a still-building index printed identically to a ready one — and that command is the gate against deploying rules ahead of the backfill, which is the failure that locks users out of their own events.

**The historical docs had no banners.** The root doc said `PROJECT_AUDIT.md` and `FEATURE_PROPOSALS.md` carry staleness banners; they carried only a `**Date:**` line. Rather than weaken the sentence, both files now have one, so a teammate who opens either directly is warned there instead of only in a table they may never see.

Also drops `notepad` from the ARCHITECTURE lifecycle table — merged into `notes` on `main`, gone from the `Event` type, surviving only in the `firestore.rules` allowlist, which is now labelled as the leftover it is.

## Scope note

Three files here are not new: `README.md` gets the one-flag fix above, and the two historical docs get the banners. They are edited because the new docs make claims about them. Everything else in this PR is a new file.

## Review notes

- Zero relative links are broken (all resolved against each doc's own directory and checked).
- No code, config, lockfile or workflow is touched, so no gate can regress. `git diff stack/15-app-config..stack/16-claude-docs` is markdown only.
- The most useful review is a correctness read: if a claim about your area is wrong, say so — that is exactly the failure mode this PR is trying to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
